### PR TITLE
feat: auto-reassign admin when current admin disconnects

### DIFF
--- a/backend/domain/spectrum/hub.go
+++ b/backend/domain/spectrum/hub.go
@@ -230,6 +230,7 @@ func (h *Hub) Routine(ctx context.Context) {
 				}
 
 				participantsDeleted := make([]string, 0, len(room.participants))
+				adminWasRemoved := false
 				participantsToNotify := make([]string, 0, len(room.participants))
 				for i, participant := range room.participants {
 					log.WithFields(log.Fields{
@@ -242,6 +243,10 @@ func (h *Hub) Routine(ctx context.Context) {
 							"now":   time.Now().Unix(),
 						}).Debug("Removing user")
 
+						if room.IsAdmin(participant.UserID) {
+							room.RemoveAdmin(participant.UserID)
+							adminWasRemoved = true
+						}
 						participant.SetRoom("")
 						delete(room.participants, i)
 						participantsDeleted = append(participantsDeleted, i)
@@ -253,6 +258,26 @@ func (h *Hub) Routine(ctx context.Context) {
 					for _, participantDeleted := range participantsDeleted {
 						reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_USERLEFT, participantDeleted)
 						h.MessageUser(participantToNotify, participantToNotify, reply)
+					}
+				}
+
+				// If an admin was removed, reassign to the first remaining participant
+				if adminWasRemoved && len(room.admins) == 0 && len(room.participants) > 0 {
+					var newAdminColor string
+					var newAdmin *User
+					for color, participant := range room.participants {
+						newAdminColor = color
+						newAdmin = participant
+						break
+					}
+					if err := room.SetAdmin(newAdmin); err == nil {
+						log.WithFields(log.Fields{
+							"roomID": roomID,
+							"color":  newAdminColor,
+							"userID": newAdmin.UserID,
+						}).Info("Admin reassigned after disconnection")
+						reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_MADEADMIN, newAdminColor)
+						h.MessageRoom(roomID, reply)
 					}
 				}
 			}

--- a/backend/domain/spectrum/room.go
+++ b/backend/domain/spectrum/room.go
@@ -140,6 +140,15 @@ func (r *Room) IsAdmin(userID string) bool {
 	return slices.Contains(r.admins, userID)
 }
 
+func (r *Room) RemoveAdmin(userID string) {
+	for i, adminID := range r.admins {
+		if adminID == userID {
+			r.admins = append(r.admins[:i], r.admins[i+1:]...)
+			return
+		}
+	}
+}
+
 func (r *Room) Close() error {
 	if r.closed {
 		return errors.New("room closed")


### PR DESCRIPTION
## Problem

When the cleanup routine removes a participant whose grace period has expired, it does not check if that participant was an admin. If they were, the room ends up with no admin, making admin-only actions (reset positions, kick, listen, disconnect live) unavailable for the rest of the session.

## Solution

### Backend (`hub.go`)
- In the cleanup routine, track whether a removed participant was an admin
- If they were, call `room.RemoveAdmin(userID)` to remove them from the admins list
- After processing all removals: if no admins remain and the room still has participants, reassign the admin role to the first remaining participant via `room.SetAdmin()`
- Broadcast `madeadmin <color>` to the room so all clients update their UI

### Backend (`room.go`)
- Add `RemoveAdmin(userID string)` method to cleanly remove a user from the admins slice

### Frontend
- No changes needed — the `madeadmin` RPC handler already handles both cases:
  - If the new admin is the current user (`otherUserId == userId`): sets `adminModeOn = true` and removes the pellet
  - If it's another participant: logs the event and removes their pellet from the canvas

## Notes
- Admin reassignment is non-deterministic (first participant in map iteration) — this is acceptable since the goal is simply to ensure at least one admin is always present
- The fix applies only when `room.admins` becomes empty after removals, so multiple admins are handled correctly (a second admin being disconnected won't trigger reassignment if another admin remains)