### PR TITLE
fix: replace panic() and log.Fatal() with proper error returns in TikTok/Twitch listeners

### DIFF
--- a/backend/domain/social/tiktok.go
+++ b/backend/domain/social/tiktok.go
@@ -3,6 +3,7 @@ package social
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -51,14 +52,14 @@ func (l *TiktokListener) Connect(ctx context.Context, liveID string, onEvent OnE
 	var err error
 	l.tiktokService, err = gotiktoklive.NewTikTok()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create TikTok client: %w", err)
 	}
 
 	log.Info("Connected to tiktok")
 
 	live, err := l.tiktokService.TrackUser(liveID)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to track TikTok user %q: %w", liveID, err)
 	}
 
 	log.Info("Connected to user live")

--- a/backend/domain/social/twitch.go
+++ b/backend/domain/social/twitch.go
@@ -2,6 +2,7 @@ package social
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	"Opinions-sur-Rue/spectrum/domain/valueobjects"
@@ -53,7 +54,7 @@ func (l *TwitchListener) Connect(ctx context.Context, liveID string, onEvent OnE
 
 	err = l.service.Connect()
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to connect to Twitch IRC: %w", err)
 	}
 
 	log.Infof("Live Chat ID: %s\n", liveID)


### PR DESCRIPTION
Closes #307

## Root cause

`TiktokListener.Connect()` used `panic()` on two error paths, and `TwitchListener.Connect()` used `log.Fatal()` on connection failure. Both crash the entire server process:

- `panic()` in a goroutine that has no recovery kills the process with no cleanup
- `log.Fatal()` calls `os.Exit(1)`, bypassing all defers and graceful shutdown

## Solution

Replace with `fmt.Errorf()` wrapping the original error. The caller (`hub.go`) already handles errors from `Connect()` inside the `listen` goroutine and sends a `nack` RPC to the client — so the error path was already designed for this.

```go
// Before
l.tiktokService, err = gotiktoklive.NewTikTok()
if err != nil {
    panic(err)
}

// After
l.tiktokService, err = gotiktoklive.NewTikTok()
if err != nil {
    return fmt.Errorf("failed to create TikTok client: %w", err)
}
```