### PR TITLE
fix: use sync.Once to prevent race condition on Hub initialization

### DIFF
--- a/backend/api/spectrum.go
+++ b/backend/api/spectrum.go
@@ -12,13 +12,14 @@ import (
 
 var (
 	spectrumHub *spectrum.Hub
+	hubOnce     sync.Once
 )
 
 func getSpectrumHub(ctx context.Context) *spectrum.Hub {
-	if spectrumHub == nil {
+	hubOnce.Do(func() {
 		spectrumHub = spectrum.NewHub()
 		go spectrumHub.Run(ctx)
-	}
+	})
 	return spectrumHub
 }
 


### PR DESCRIPTION
Closes #306

## Root cause

`getSpectrumHub()` used a plain nil check to initialize the Hub:

```go
if spectrumHub == nil {   // ← data race
    spectrumHub = spectrum.NewHub()
    go spectrumHub.Run(ctx)
}
```

Two concurrent WebSocket connections arriving at startup could both read `spectrumHub == nil` before either has written to it, causing the Hub to be initialized twice. The second write overwrites the first, potentially leaking the first `Run()` goroutine and losing any clients already registered to it.

Detectable with `go test -race`.

## Solution

`sync.Once` guarantees `getSpectrumHub()` initializes the Hub exactly once, regardless of concurrent callers — no mutex boilerplate needed.