### PR TITLE
fix: use VITE_DEBUG env var to control debug logging (was always true in production)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 VITE_VERSION=1.0.0
 VITE_API_URL=https://api.spectrum.utile.space
 VITE_PUBLIC_URL=https://spectrum.utile.space
+# Set to 'true' to enable debug logging in the browser console (default: false)
+VITE_DEBUG=false
 
 # Backend
 API_PORT=3000

--- a/frontend/src/lib/env.js
+++ b/frontend/src/lib/env.js
@@ -1,4 +1,6 @@
-export const DEBUG = import.meta.env.DEBUG ?? true;
+// VITE_DEBUG=true enables debug logging. Defaults to false.
+// (Vite only exposes env vars prefixed with VITE_ to the client bundle)
+export const DEBUG = import.meta.env.VITE_DEBUG === 'true';
 
 export const PUBLIC_VERSION = import.meta.env.VITE_VERSION ?? 'N.A';
 


### PR DESCRIPTION
Closes #302

## Root cause

`src/lib/env.js` used `import.meta.env.DEBUG` which Vite never injects — only variables prefixed with `VITE_` are exposed to the client bundle. The value was always `undefined`, triggering the `?? true` fallback, so `DEBUG` was always `true` in production.

## Fix

```js
// Before
export const DEBUG = import.meta.env.DEBUG ?? true;

// After
export const DEBUG = import.meta.env.VITE_DEBUG === 'true';
```

Defaults to `false` when `VITE_DEBUG` is unset. Set `VITE_DEBUG=true` in your local `.env` to enable debug logging during development.

Also documented in `.env.example`.