### PR TITLE
feat: improve reconnection feedback when WebSocket connection is lost

### DIFF
--- a/frontend/src/lib/spectrum/websocket.svelte.ts
+++ b/frontend/src/lib/spectrum/websocket.svelte.ts
@@ -4,8 +4,8 @@ const WS_URL = API_URL.replace('http://', 'ws://').replace('https://', 'wss://')
 
 let websocket: WebSocket;
 
-/** True while the WebSocket is disconnected and a reconnect attempt is pending. */
-export let reconnecting = $state(false);
+/** Reactive WebSocket state. Use wsState.reconnecting in templates. */
+export const wsState = $state({ reconnecting: false });
 
 export function startWebsocket(
 	onOpenCallback: () => void,
@@ -19,7 +19,7 @@ export function startWebsocket(
 	websocket.onclose = async function (evt) {
 		console.warn('Websocket connection lost: ' + evt.reason);
 
-		reconnecting = true;
+		wsState.reconnecting = true;
 
 		if (onCloseCallback) await onCloseCallback();
 
@@ -41,7 +41,7 @@ export function startWebsocket(
 	};
 
 	websocket.onopen = async function () {
-		reconnecting = false;
+		wsState.reconnecting = false;
 		if (onOpenCallback) await onOpenCallback();
 	};
 

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -41,7 +41,7 @@
 	import JoinSpectrumModal from '$lib/components/JoinSpectrumModal.svelte';
 	import ConnectLiveModal from '$lib/components/ConnectLiveModal.svelte';
 	import { ENABLE_AUDIO, HEADER_TITLE, LOGO_URL, LOGO_WIDTH, PUBLIC_URL } from '$lib/env';
-	import { startWebsocket, reconnecting } from '$lib/spectrum/websocket.svelte';
+	import { startWebsocket, wsState } from '$lib/spectrum/websocket.svelte';
 	import { Canvas, loadSVGFromURL, util } from 'fabric';
 	import { onMount, tick } from 'svelte';
 	import { copy } from 'svelte-copy';
@@ -670,7 +670,7 @@
 	let wasReconnecting = false;
 
 	function signIn() {
-		if ($reconnecting) {
+		if (wsState.reconnecting) {
 			wasReconnecting = true;
 		}
 		rpc('signin', getUserId());
@@ -1114,7 +1114,7 @@
 			<span class="px-4 py-2">
 				{#if !initialized}
 					<span class="loading loading-spinner loading-md text-success"></span> Loading...
-				{:else if reconnecting}
+				{:else if wsState.reconnecting}
 					<span class="loading loading-spinner loading-sm text-warning"></span>
 					<span class="text-warning font-mono text-sm">Reconnecting...</span>
 				{:else}


### PR DESCRIPTION
Closes #305

## Problem

When the WebSocket disconnects, `connectionLost()` only showed a toast error. During the 5-second retry window, the UI was indistinguishable from a connected state — no persistent indicator, no history log.

## Changes

### `websocket.ts`
- Export a `reconnecting` Svelte store (`writable<boolean>`)
- Set to `true` on `onclose`, back to `false` on `onopen`

### `+page.svelte`
- Import `reconnecting` store
- Header status area: show a spinner + **Reconnecting...** warning while reconnecting (replaces the green/red status dot)
- `connectionLost()`: also log the disconnection in the chat history (not just a toast)
- `signIn()` + `parseCommand(ack/signin)`: detect when reconnection succeeded and log **✓ Reconnected** in the chat history