### PR TITLE
fix: resolve all svelte-check TypeScript errors and remove @ts-nocheck

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
 				"@tailwindcss/vite": "^4.2.2",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.3.1",
+				"@types/node": "^25.5.0",
 				"daisyui": "^5.5.19",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^10.1.8",
@@ -2421,6 +2422,16 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
@@ -6502,6 +6513,13 @@
 			"engines": {
 				"node": ">=20.18.1"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unplugin": {
 			"version": "2.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
 		"@tailwindcss/vite": "^4.2.2",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
+		"@types/node": "^25.5.0",
 		"daisyui": "^5.5.19",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^10.1.8",

--- a/frontend/src/lib/components/EmojiBurst.svelte
+++ b/frontend/src/lib/components/EmojiBurst.svelte
@@ -6,7 +6,7 @@
 
 	let show = false;
 	let element: HTMLDivElement;
-	let timeout: number | undefined;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
 
 	$: if (trigger) {
 		if (timeout) clearTimeout(timeout);

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	/* eslint-disable */
-	// @ts-nocheck
-	/* eslint svelte/no-at-html-tags: "off" */
 
 	import Header from '$lib/components/Header.svelte';
 	import {
@@ -100,7 +97,19 @@
 	let moving = false;
 	const cells: any[] = [];
 	const cellsPoints: any[] = [];
-	const others: any = $state({});
+	interface Participant {
+		pellet: ReturnType<typeof newPellet> | null;
+		target?: { x: number; y: number };
+		nickname: string;
+		microphone: boolean;
+		volume: number;
+		voiceId?: string;
+		audio?: HTMLAudioElement;
+		averageVoice?: number;
+		validateOpinion?: ReturnType<typeof setTimeout>;
+	}
+
+	const others = $state<Record<string, Participant>>({});
 
 	let claim: string = $state('');
 	let scale: number;
@@ -525,11 +534,11 @@
 		setInterval(updateMyPellet, updateTick);
 	}
 
-	function initOtherPellet(userId: string, nickname: string, pictureUrl?: string) {
+	function initOtherPellet(userId: string, nickname: string) {
 		console.log('Initalizing Other Pellet: ' + userId);
 		log(m.log_joined_spectrum({ name: nickname }), 'join');
 
-		const pellet = newPellet(userId, nickname, pictureUrl);
+		const pellet = newPellet(userId, nickname);
 
 		pellet.set({
 			top: (canvasWidth * originalHeight) / originalWidth / 2,
@@ -580,7 +589,7 @@
 		if (others[otherUserId].pellet) {
 			myCanvas.remove(others[otherUserId].pellet);
 			myCanvas.renderAll();
-			delete others[otherUserId].pellet;
+			others[otherUserId].pellet = null;
 		}
 
 		if (!keepUser) {
@@ -625,6 +634,8 @@
 			if (!pellet) continue;
 			const currentX = pellet.left ?? 0;
 			const currentY = pellet.top ?? 0;
+
+			if (!target) continue;
 
 			pellet.set({
 				left: lerp(currentX, target.x * scale, t),
@@ -823,7 +834,7 @@
 
 				if (emoji === '🤚') {
 					handAnimation = true;
-					handUsername = otherUserId != userId ? others[otherUserId].nickname : nickname;
+					handUsername = otherUserId != userId ? others[otherUserId].nickname : (nickname ?? '');
 				}
 
 				requestAnimationFrame(() => (trigger = true)); // retrigger animation
@@ -943,7 +954,7 @@
 		}
 	}
 
-	let updateClaimLog: number | undefined;
+	let updateClaimLog: ReturnType<typeof setTimeout> | undefined;
 	let previousClaim: string | undefined;
 
 	function connectionLost() {
@@ -1038,7 +1049,7 @@
 		const userIdColor = stringToColorHex(liveUserId);
 
 		others[userIdColor] = {
-			pellet: initOtherPellet(userIdColor, liveUserNickname, liveUserPictureUrl),
+			pellet: initOtherPellet(userIdColor, liveUserNickname),
 			target: convertVoteToPosition(liveVotes.get(liveUserId)),
 			nickname: liveUserNickname,
 			microphone: false,
@@ -1084,7 +1095,7 @@
 		if (!ENABLE_AUDIO) return;
 
 		others[userId].volume = volume;
-		others[userId].audio.volume = volume / 100;
+		if (others[userId].audio) others[userId].audio!.volume = volume / 100;
 	}
 </script>
 
@@ -1388,7 +1399,7 @@
 									{#if ENABLE_AUDIO}
 										<label
 											class="swap swap-flip cursor-default"
-											class:swap-active={(other as any).microphone}
+											class:swap-active={other.microphone}
 										>
 											<div class="swap-on">
 												<Fa icon={faMicrophone} />
@@ -1398,7 +1409,7 @@
 											</div>
 										</label>
 									{/if}
-									<span class="text-sm"><b>{(other as any).nickname}</b></span>
+									<span class="text-sm"><b>{other.nickname}</b></span>
 								</td>
 								<td>
 									<div class="dropdown dropdown-hover dropdown-bottom dropdown-center">
@@ -1420,7 +1431,7 @@
 										<div class="dropdown-content bg-base-200 rounded-box w-48 p-4 shadow">
 											<label class="label">
 												<span class="label-text"
-													>{m.volume_of({ name: (other as any).nickname })}</span
+													>{m.volume_of({ name: other.nickname })}</span
 												>
 											</label>
 											<input
@@ -1430,7 +1441,7 @@
 												value="100"
 												class="range range-xs"
 												oninput={(e) => {
-													setVolume(colorHex, +e.target?.value);
+													setVolume(colorHex, +(e.target as HTMLInputElement)?.value);
 												}}
 											/>
 										</div>
@@ -1533,13 +1544,13 @@
 							<!-- Participant info -->
 							<div class="flex-1">
 								<div class="truncate text-base font-bold">
-									{(other as any).nickname}
+									{other.nickname}
 								</div>
 								<div class="text-sm text-gray-500">
 									{#if ENABLE_AUDIO}
 										<label
 											class="swap swap-flip cursor-default"
-											class:swap-active={(other as any).microphone}
+											class:swap-active={other.microphone}
 										>
 											<div class="swap-on">
 												<Fa icon={faMicrophone} />

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-
 	import Header from '$lib/components/Header.svelte';
 	import {
 		faCirclePlus,
@@ -1430,9 +1429,7 @@
 
 										<div class="dropdown-content bg-base-200 rounded-box w-48 p-4 shadow">
 											<label class="label">
-												<span class="label-text"
-													>{m.volume_of({ name: other.nickname })}</span
-												>
+												<span class="label-text">{m.volume_of({ name: other.nickname })}</span>
 											</label>
 											<input
 												type="range"

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -26,7 +26,6 @@
 		faUserSlash,
 		faVolumeHigh,
 		faVolumeLow,
-		faVolumeMute,
 		faVolumeOff,
 		faVolumeXmark
 	} from '@fortawesome/free-solid-svg-icons';
@@ -40,10 +39,10 @@
 	import { startWebsocket, wsState } from '$lib/spectrum/websocket.svelte';
 	import { Canvas, loadSVGFromURL, util } from 'fabric';
 	import { onMount, tick } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
 	import { copy } from 'svelte-copy';
 	import { capitalize, lerp, pointInPolygon, stringToColorHex } from '$lib/utils';
 	import Peer from 'peerjs';
-	import * as pkg from 'peerjs';
 	import EmojiBurst from '$lib/components/EmojiBurst.svelte';
 	import InputFlex from '$lib/components/InputFlex.svelte';
 	import { m } from '$lib/paraglide/messages.js';
@@ -52,6 +51,7 @@
 	import { newPellet } from '$lib/canvas/pellet';
 	import type { LiveUser } from '$lib/social';
 
+	// eslint-disable-next-line svelte/valid-prop-names-in-kit-pages
 	let { id: spectrumId }: { id: string | undefined } = $props();
 
 	const opinions = {
@@ -92,9 +92,11 @@
 
 	let logs: Log[] = $state([]);
 
-	let myPellet: any = $state();
+	let myPellet: ReturnType<typeof newPellet> | null = $state(null);
 	let moving = false;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const cells: any[] = [];
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const cellsPoints: any[] = [];
 	interface Participant {
 		pellet: ReturnType<typeof newPellet> | null;
@@ -113,15 +115,15 @@
 	let claim: string = $state('');
 	let scale: number;
 
-	let tbodyRef: any; // Reference to tbody
+	let tbodyRef: HTMLDivElement | undefined; // Reference to tbody
 
 	let localStream: MediaStream | undefined = $state();
 	let peer: Peer;
 	let peerId: string | undefined = $state();
 	let peerConnected = $state(false);
-	const connections = new Map<string, MediaStream>();
+	const connections = new SvelteMap<string, MediaStream>();
 	let microphone: boolean = $state(false);
-	const voiceIdToUserId = new Map<string, string>();
+	const voiceIdToUserId = new SvelteMap<string, string>();
 
 	function validateOpinion(otherUserId: string) {
 		const target = others[otherUserId].pellet;
@@ -219,13 +221,14 @@
 		}
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let svg: any;
 	let averageVoice: number = $state(0);
 	let voiceIndicator = $derived(1 + averageVoice / 100);
 	let otherVoices = $derived.by(() => {
-		const voices: any = {};
+		const voices: Record<string, number> = {};
 		for (const [key, other] of Object.entries(others)) {
-			voices[key] = 1 + ((other as any).averageVoice ?? 0) / 100;
+			voices[key] = 1 + ((other as Participant).averageVoice ?? 0) / 100;
 		}
 		return voices;
 	});
@@ -241,7 +244,8 @@
 				}
 			});
 
-			const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+			const audioContext = new (window.AudioContext ||
+				(window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
 
 			const source = audioContext.createMediaStreamSource(localStream);
 
@@ -281,7 +285,7 @@
 		console.log('Playing audio for voiceId:', voiceId);
 		let otherId: string | undefined;
 		for (const [key, value] of Object.entries(others)) {
-			if ((value as any).voiceId === voiceId) {
+			if ((value as Participant).voiceId === voiceId) {
 				otherId = key;
 				break;
 			}
@@ -293,7 +297,8 @@
 		audio.autoplay = true;
 		audio.play().catch(console.error);
 
-		const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+		const audioContext = new (window.AudioContext ||
+			(window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
 
 		const source = audioContext.createMediaStreamSource(stream);
 
@@ -372,7 +377,7 @@
 				setTimeout(() => connectToPeer(), 1000);
 			} else if (err.type === 'peer-unavailable') {
 				console.log('Failed to connect with peer, trying again');
-				const match = err.message.match(/[0-9a-fA-F\-]{36}$/);
+				const match = err.message.match(/[0-9a-fA-F-]{36}$/);
 				if (match) {
 					const peerId = match[0];
 					console.log('Peer ID:', peerId);
@@ -437,9 +442,9 @@
 			}
 		});
 
-		// @ts-ignore
+		// @ts-expect-error -- loadSVGFromURL return type not fully typed
 		loadSVGFromURL(m.file_spectrum()).then(({ objects, options }) => {
-			// @ts-ignore
+			// @ts-expect-error -- groupSVGElements return type not fully typed
 			svg = util.groupSVGElements(objects, options);
 
 			// Get canvas dimensions
@@ -656,7 +661,7 @@
 	}
 
 	function drawCanvas(id: string) {
-		// @ts-ignore
+		// @ts-expect-error -- Canvas constructor options
 		const canvas = new Canvas(id);
 		canvas.hoverCursor = 'pointer';
 		canvas.selection = false;
@@ -701,8 +706,8 @@
 		return { x, y };
 	}
 
-	let liveVotes = new Map<string, number>();
-	let liveUsers = new Map<string, LiveUser>();
+	let liveVotes = new SvelteMap<string, number>();
+	let liveUsers = new SvelteMap<string, LiveUser>();
 
 	function saveLiveUser(
 		liveUserId: string,
@@ -1026,6 +1031,7 @@
 	}
 
 	let showAddLiveUserParticipantModal = $state(false);
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function toggleAddLiveUserParticipantModal() {
 		showAddLiveUserParticipantModal = !showAddLiveUserParticipantModal;
 	}
@@ -1040,11 +1046,7 @@
 		toggleConnectLiveModal();
 	}
 
-	function onAddLiveUserParticipant(
-		liveUserId: string,
-		liveUserNickname: string,
-		liveUserPictureUrl?: string
-	) {
+	function onAddLiveUserParticipant(liveUserId: string, liveUserNickname: string) {
 		const userIdColor = stringToColorHex(liveUserId);
 
 		others[userIdColor] = {
@@ -1077,7 +1079,7 @@
 
 	let streamerMode = $state(false);
 
-	function toggleMicrophone(event: MouseEvent & { currentTarget: EventTarget & HTMLLabelElement }) {
+	function toggleMicrophone() {
 		microphone = !microphone;
 
 		// Open microphone for first time, will trigger permission etc, and then call everybody we knew who had voiceId
@@ -1357,7 +1359,7 @@
 											<!-- svelte-ignore a11y_click_events_have_key_events -->
 											<label
 												class="swap indicator"
-												onclick={toggleMicrophone}
+												onclick={() => toggleMicrophone()}
 												class:swap-active={microphone && peerConnected}
 											>
 												<div class="swap-on btn btn-ghost btn-square rounded-xl">
@@ -1377,7 +1379,7 @@
 								</td>
 							</tr>
 						{/if}
-						{#each Object.entries(others) as [colorHex, other]}
+						{#each Object.entries(others) as [colorHex, other] (colorHex)}
 							<tr class="even:bg-base-100">
 								<td>
 									<div class="inline-grid *:[grid-area:1/1]">
@@ -1520,7 +1522,7 @@
 						</div>
 					</div>
 				</div>
-				{#each Object.entries(others) as [colorHex, other]}
+				{#each Object.entries(others) as [colorHex, other] (colorHex)}
 					<div class="card bg-base-100 border-base-300 w-full border p-4 shadow-md">
 						<div class="flex items-center space-x-4">
 							<!-- Avatar or status indicator -->
@@ -1581,7 +1583,7 @@
 					onmouseenter={() => (isHoveringHistory = true)}
 					onmouseleave={() => (isHoveringHistory = false)}
 				>
-					{#each logs as log, i}
+					{#each logs as log (log.message + log.type)}
 						{@const regex = /^\[([^\]]+)\]\s*(.*)$/}
 						{@const match = log.message.match(regex)}
 						<div class="even:bg-base-100 px-4 py-1">


### PR DESCRIPTION
Closes #304

## Summary

Went from **62 TypeScript errors** to **0**, then removed `@ts-nocheck` from `+page.svelte`.

## Root causes fixed

| Errors | Fix |
|---|---|
| 42 × `IconDefinition` type mismatch | Bump `@fortawesome/free-brands-svg-icons` to `7.2.0` — deduplicates `fontawesome-common-types` |
| 1 × `Cannot find module 'async_hooks'` | Add `@types/node` dev dependency |
| 7 × `'other' is of type 'unknown'` | Add `Participant` interface for the `others` state map |
| 2 × `Expected 2 arguments, but got 3` | Remove unused `pictureUrl` arg from `initOtherPellet` calls |
| 1 × `delete operator must be optional` | Replace `delete others[id].pellet` with `= null` |
| 2 × `'target' is possibly undefined` | Guard against undefined target in `animatePellets` |
| 2 × `Type 'Timeout' not assignable to 'number'` | Use `ReturnType<typeof setTimeout>` instead of `number` |
| 1 × `string | undefined not assignable to string` | Nullish coalesce on `nickname` |
| 1 × `Property 'value' does not exist on EventTarget` | Cast `e.target` as `HTMLInputElement` |

## Also
- Remove all remaining `(other as any)` casts in the template — now properly typed through the `Participant` interface
- `@ts-nocheck` removed from `+page.svelte`