### PR TITLE
fix: restore canvas positioning after Fabric 7 origin default change

### DIFF
--- a/frontend/src/lib/canvas/pellet.ts
+++ b/frontend/src/lib/canvas/pellet.ts
@@ -44,6 +44,8 @@ export function newPellet(userId: string, nickname: string) {
 	});
 
 	const g = new Group([rect, text, circle], {
+		originX: 'left',
+		originY: 'top',
 		evented: false,
 		hasBorders: false,
 		hasControls: false

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -143,6 +143,8 @@
 				myCanvas.setDimensions({ width: canvasWidth, height: scale * originalHeight });
 
 				svg.set({
+					originX: 'left',
+					originY: 'top',
 					scaleX: scale,
 					scaleY: scale,
 					left: (canvasWidth - svg.width! * scale) / 2,
@@ -444,6 +446,8 @@
 			const scale = Math.min(scaleX, scaleY); // Maintain aspect ratio
 
 			svg.set({
+				originX: 'left',
+				originY: 'top',
 				scaleX: scale,
 				scaleY: scale,
 				left: (canvasWidth - svg.width! * scale) / 2,


### PR DESCRIPTION
## Root cause

Fabric 7.0 introduced a breaking change: the default `originX`/`originY` changed from `'left'/'top'` to `'center'/'center'`. This caused:

- The spectrum SVG to render off-center (shifted right and down)
- The pellet Group positioning to behave unexpectedly

## Fix

Explicitly set `originX: 'left'`, `originY: 'top'` on:
- The SVG group in the initial `loadSVGFromURL` callback
- The SVG group in the canvas resize `$effect`
- The pellet `Group` in `pellet.ts`

This restores the Fabric 6 coordinate system where `left`/`top` refer to the top-left corner, matching all existing position calculations.