### PR TITLE
fix: align fontawesome deps and add @types/node to fix svelte-check errors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
 				"@tailwindcss/vite": "^4.2.2",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.3.1",
+				"@types/node": "^25.5.0",
 				"daisyui": "^5.5.19",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^10.1.8",
@@ -2421,6 +2422,16 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
@@ -6502,6 +6513,13 @@
 			"engines": {
 				"node": ">=20.18.1"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unplugin": {
 			"version": "2.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
 		"@tailwindcss/vite": "^4.2.2",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
+		"@types/node": "^25.5.0",
 		"daisyui": "^5.5.19",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Changes

**1. Bump `@fortawesome/free-brands-svg-icons` to `^7.2.0`**

`free-solid-svg-icons@7.2.0` and `free-brands-svg-icons@7.1.0` depended on different versions of `@fortawesome/fontawesome-common-types`, causing 42 TypeScript type incompatibility errors (`IconDefinition`/`IconPrefix` mismatch). Aligning to `7.2.0` deduplicates the transitive dependency.

**2. Add `@types/node` as dev dependency**

`paraglide-js` server internals use `async_hooks` (Node.js built-in). Without `@types/node`, svelte-check reports `Cannot find module 'async_hooks'`.