### PR TITLE
chore: minor backend quality improvements in utils.go

### DIFF
--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -20,33 +21,44 @@ func EnableCors(next http.Handler) http.Handler {
 }
 
 func Output(w http.ResponseWriter, accept []string, v interface{}, plain string) {
-	fmt.Fprint(w, computeOutput(accept, v, plain))
-}
-
-func computeOutput(accept []string, v interface{}, plain string) string {
-	if slices.Contains(accept, "application/json") {
-		reply, _ := json.Marshal(v)
-		return string(reply)
-	} else if slices.Contains(accept, "application/xml") {
-		reply, _ := xml.Marshal(v)
-		return string(reply)
-	} else if slices.Contains(accept, "application/yaml") {
-		reply, _ := yaml.Marshal(v)
-		return string(reply)
-	} else {
-		return plain
+	output, err := computeOutput(accept, v, plain)
+	if err != nil {
+		log.WithError(err).Error("Failed to marshal response")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
+	fmt.Fprint(w, output)
 }
 
-// from ChatGPT
+func computeOutput(accept []string, v interface{}, plain string) (string, error) {
+	if slices.Contains(accept, "application/json") {
+		reply, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(reply), nil
+	} else if slices.Contains(accept, "application/xml") {
+		reply, err := xml.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(reply), nil
+	} else if slices.Contains(accept, "application/yaml") {
+		reply, err := yaml.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(reply), nil
+	}
+	return plain, nil
+}
+
 func GenerateRandomString(length int) string {
-	// Allowed characters
 	allowedChars := "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789"
 
 	randString := make([]byte, length)
 
 	for i := 0; i < length; i++ {
-		// Choose a random character from the allowedChars
 		randString[i] = allowedChars[rand.Intn(len(allowedChars))]
 	}
 

--- a/backend/utils/utils_test.go
+++ b/backend/utils/utils_test.go
@@ -47,7 +47,8 @@ func Test_computeOutput(t *testing.T) {
 
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
-			result := computeOutput(tc.acceptHeader, tc.reply, tc.plain)
+			result, err := computeOutput(tc.acceptHeader, tc.reply, tc.plain)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
Closes #311

## Changes

**Remove `// from ChatGPT` comment**
Not useful in production code.

**Handle marshaling errors in `computeOutput` / `Output`**

Previously errors were silently ignored:
```go
reply, _ := json.Marshal(v)  // error discarded
```

Now `computeOutput` returns `(string, error)` and `Output` logs the error and returns HTTP 500 if marshaling fails.

**Update test** to assert `err == nil`.