### PR TITLE
fix: rework pellet layout for Fabric 7 group coordinate system

### DIFF
--- a/frontend/src/lib/canvas/pellet.ts
+++ b/frontend/src/lib/canvas/pellet.ts
@@ -10,7 +10,7 @@ export function newPellet(userId: string, nickname: string) {
 
 	const circle = new Circle({
 		left: RADIUS, // center of circle
-		top: 0,       // vertical center
+		top: 0, // vertical center
 		radius: RADIUS,
 		originX: 'center',
 		originY: 'center',


### PR DESCRIPTION
Follow-up to #371 — the first fix still had the layout broken.

In Fabric 7, Group recalculates child positions relative to its computed center. This commit reworks the layout properly: circle with center origin at (RADIUS, 0), rect and text positioned right of the circle with left/center origin.