### PR TITLE
refactor: extract room state into $lib/spectrum/room store

### DIFF
--- a/frontend/src/lib/spectrum/room.svelte.ts
+++ b/frontend/src/lib/spectrum/room.svelte.ts
@@ -85,10 +85,7 @@ export function leaveRoom() {
 	room.listening = false;
 	room.liveChannel = undefined;
 	room.liveListening = false;
-	// Clear all participants
-	for (const key in room.others) {
-		delete room.others[key];
-	}
+	room.others = {};
 }
 
 export function removeParticipant(colorHex: string) {

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -61,6 +61,13 @@
 	// eslint-disable-next-line svelte/valid-prop-names-in-kit-pages
 	let { id: spectrumId }: { id: string | undefined } = $props();
 
+	// Keep room store in sync with the SvelteKit route param.
+	// spectrumId (prop) is the source of truth for the URL;
+	// room.spectrumId is used by other modules (voice callbacks etc.)
+	$effect(() => {
+		room.spectrumId = spectrumId;
+	});
+
 	const opinions = {
 		stronglyAgree: m.opinion_strongly_agree(),
 		agree: m.opinion_agree(),


### PR DESCRIPTION
Part of #301 — God Component refactor (step 2/4: room store)

## Changes

**New:** `src/lib/spectrum/room.svelte.ts`

Single exported `room` object with reactive state:
- `spectrumId`, `userId`, `nickname`, `initialized`, `adminModeOn`
- `claim` — current spectrum topic
- `others` — `Record<string, Participant>` for all participants
- `logs` — chat/event history
- `listening`, `liveChannel`, `liveListening`

Also exports `Participant` and `Log` types (shared with voice module and future modules).

**Modified:** `+page.svelte`

The page now accesses `room.xxx` directly. All previous local `$state` declarations for session state are removed.