### PR TITLE
refactor: extract RPC dispatch from parseCommand (#301 step 3)

### DIFF
--- a/frontend/src/lib/spectrum/websocket.svelte.ts
+++ b/frontend/src/lib/spectrum/websocket.svelte.ts
@@ -1,5 +1,3 @@
-import { SvelteMap } from 'svelte/reactivity';
-
 import { API_URL, DEBUG } from '$lib/env';
 
 const WS_URL = API_URL.replace('http://', 'ws://').replace('https://', 'wss://');
@@ -15,7 +13,8 @@ export const wsState = $state({ reconnecting: false });
 
 export type RpcHandler = (args: string[]) => void;
 
-const handlers = new SvelteMap<string, RpcHandler>();
+// eslint-disable-next-line svelte/prefer-svelte-reactivity -- not reactive state, internal dispatch table only
+const handlers = new Map<string, RpcHandler>();
 
 /**
  * Register a handler for a specific RPC command.

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -36,9 +36,14 @@
 	import JoinSpectrumModal from '$lib/components/JoinSpectrumModal.svelte';
 	import ConnectLiveModal from '$lib/components/ConnectLiveModal.svelte';
 	import { ENABLE_AUDIO, HEADER_TITLE, LOGO_URL, LOGO_WIDTH, PUBLIC_URL } from '$lib/env';
-	import { startWebsocket, wsState, registerHandler } from '$lib/spectrum/websocket.svelte';
+	import {
+		startWebsocket,
+		wsState,
+		registerHandler,
+		unregisterHandler
+	} from '$lib/spectrum/websocket.svelte';
 	import { Canvas, loadSVGFromURL, util } from 'fabric';
-	import { onMount, tick, untrack } from 'svelte';
+	import { onMount, onDestroy, tick, untrack } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { copy } from 'svelte-copy';
 	import { capitalize, lerp, pointInPolygon, stringToColorHex } from '$lib/utils';
@@ -409,6 +414,23 @@
 		});
 
 		websocket = startWebsocket(signIn, connectionLost);
+		registeredCommands = [
+			'ack',
+			'nack',
+			'spectrum',
+			'update',
+			'userleft',
+			'receive',
+			'madeadmin',
+			'newposition',
+			'claim',
+			'voicechat',
+			'microphonemuted',
+			'microphoneunmuted',
+			'listenning',
+			'liveusermessage',
+			'chatmessage'
+		];
 
 		// Prepare Both Canvas
 		myCanvas = drawCanvas('spectrum');
@@ -661,6 +683,14 @@
 
 		return canvas;
 	}
+
+	let registeredCommands: string[] = [];
+
+	onDestroy(() => {
+		for (const command of registeredCommands) {
+			unregisterHandler(command);
+		}
+	});
 
 	let wasReconnecting = false;
 


### PR DESCRIPTION
## Summary

Part of #301 — Refactor God Component in `+page.svelte`.

**Step 3: RPC dispatch** (steps 1 voice ✅, step 2 room store ✅ already merged)

## What changed

### `websocket.svelte.ts`

- Added `registerHandler(command, handler)` / `unregisterHandler(command)` exports
- Added internal `dispatch(line)` function that parses JSON and routes to the registered handler via a `Map<string, RpcHandler>`
- Removed `onMessageCallback` param from `startWebsocket()` (now handled internally)
- Exported `RpcHandler` type

### `+page.svelte`

- Removed the 25-branch `parseCommand()` function entirely
- Registered all 15 RPC command handlers via `registerHandler()` in `onMount()`
- Updated `startWebsocket()` call (removed `parseCommand` arg)

## No functional changes

All handler logic remains in `+page.svelte`. The dispatch mechanism is now extensible — future modules can register their own handlers without touching the page component.

## TypeScript

No new errors introduced. The 5 pre-existing errors (nullable `myPellet`, unused `@ts-expect-error`) are unchanged.