### PR TITLE
fix: ghost pellet for admin when new participant joins

### DIFF
--- a/backend/domain/spectrum/room.go
+++ b/backend/domain/spectrum/room.go
@@ -129,6 +129,7 @@ func (r *Room) SetAdmin(user *User) error {
 		return errors.New("room closed")
 	}
 	r.admins = append(r.admins, user.UserID)
+	user.SetLastPosition("")
 	return nil
 }
 


### PR DESCRIPTION
## Problem

When a participant is reassigned as admin via `reassignAdminLocked` (triggered when the previous admin leaves), `SetAdmin(user)` was called without clearing the user's last position. 

So when a new participant joins the room afterwards, the server broadcasts an `update` RPC for all participants including the new admin — with their last valid position. The client then calls `updatePellet` with a non-null coord and creates a pellet for the admin, even though admins shouldn't have one.

## Root cause

`SetAdminByColor` (used for manual `makeadmin`) correctly calls `SetLastPosition("")`:
```go
r.admins = append(r.admins, r.participants[color].UserID)
r.participants[color].SetLastPosition("")  // ✅
```

But `SetAdmin` (used for automatic reassignment) did not:
```go
r.admins = append(r.admins, user.UserID)
// missing SetLastPosition  ❌
```

## Fix

Added `user.SetLastPosition("")` in `SetAdmin`, making both paths consistent.