### PR TITLE
ci: name APK artifacts by branch/PR

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -61,6 +61,6 @@ jobs:
       - name: 📤 Upload APK artifact
         uses: actions/upload-artifact@v7
         with:
-          name: spectrum-debug-apk
+          name: spectrum-debug-apk-${{ github.ref_name == 'main' && 'main' || github.event.pull_request.number }}
           path: frontend/android/app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 30
+          retention-days: ${{ github.ref_name == 'main' && 90 || 30 }}


### PR DESCRIPTION
Le workflow buildait déjà sur main, mais les artifacts étaient tous nommés `spectrum-debug-apk` sans distinction.

## Changes
- Build main → artifact `spectrum-debug-apk-main` conservé 90 jours
- Build PR → artifact `spectrum-debug-apk-<numéro PR>` conservé 30 jours

Ça permet de toujours avoir le dernier build de main accessible distinctement des builds de PR.