### PR TITLE
ci: publish nightly APK to GitHub Releases on each main push

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -12,6 +12,9 @@ on:
       - 'frontend/**'
       - 'android/**'
 
+permissions:
+  contents: write
+
 jobs:
   build-apk:
     runs-on: ubuntu-latest
@@ -64,3 +67,19 @@ jobs:
           name: spectrum-debug-apk-${{ github.ref_name == 'main' && 'main' || github.event.pull_request.number }}
           path: frontend/android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: ${{ github.ref_name == 'main' && 90 || 30 }}
+
+      - name: 🏷️ Update nightly release (main only)
+        if: github.ref_name == 'main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: "Nightly (debug APK)"
+          body: |
+            Debug APK auto-generated from the latest `main` commit.
+
+            **⚠️ This is a debug build — not for production use.**
+
+            Built from: ${{ github.sha }}
+            Date: ${{ github.event.head_commit.timestamp }}
+          prerelease: true
+          files: frontend/android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -72,8 +72,8 @@ jobs:
         if: github.ref_name == 'main'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: nightly
-          name: "Nightly (debug APK)"
+          tag_name: latest-debug
+          name: "Latest Debug APK"
           body: |
             Debug APK auto-generated from the latest `main` commit.
 


### PR DESCRIPTION
## Problem
The APK had a different name and link on every PR/merge — no stable URL.

## Fix
On each push to `main`, the workflow creates/overwrites a GitHub Release with the fixed tag `latest-debug`.

**Permanent APK URL:**
```
https://github.com/Opinions-sur-Rue/spectrum/releases/download/latest-debug/app-debug.apk
```

- Tag `latest-debug` is recreated/updated on every main push
- Release is marked `prerelease: true`
- PR artifacts continue to work normally (no release published for PRs)
- `permissions: contents: write` added to the workflow