### PR TITLE
feat: spectrum slices choice (3 or 7) 

### DIFF
--- a/backend/domain/spectrum/room.go
+++ b/backend/domain/spectrum/room.go
@@ -29,11 +29,19 @@ type Room struct {
 	participants       map[string]*User
 	socialListener     social.ChatListener
 	showNeutralCircle  bool
+	sliceCount         int
 	participantsHidden bool
 }
 
 func (r *Room) ShowNeutralCircle() bool {
 	return r.showNeutralCircle
+}
+
+func (r *Room) SliceCount() int {
+	if r.sliceCount == 0 {
+		return 7
+	}
+	return r.sliceCount
 }
 
 func (r *Room) Join(newUser *User) error {

--- a/backend/domain/spectrum/rpc.go
+++ b/backend/domain/spectrum/rpc.go
@@ -68,7 +68,7 @@ func (c *Client) EvaluateRPC(rpc *valueobjects.MessageContent) error {
 			roomID := user.currentRoomID
 			c.hub.WithRoomRead(roomID, func(room *Room) {
 				admin := slices.Contains(room.admins, c.userID)
-				reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_SPECTRUM, user.Color, roomID, user.Nickname, fmt.Sprintf("%t", admin), fmt.Sprintf("%t", room.showNeutralCircle))
+				reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_SPECTRUM, user.Color, roomID, user.Nickname, fmt.Sprintf("%t", admin), fmt.Sprintf("%t", room.showNeutralCircle), fmt.Sprintf("%d", room.SliceCount()))
 				c.send <- reply.Export()
 
 				for _, participant := range room.participants {

--- a/backend/domain/spectrum/rpc.go
+++ b/backend/domain/spectrum/rpc.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"regexp"
 	"slices"
+	"strconv"
 
 	"Opinions-sur-Rue/spectrum/domain/social"
 	"Opinions-sur-Rue/spectrum/domain/valueobjects"
@@ -123,12 +124,19 @@ func (c *Client) EvaluateRPC(rpc *valueobjects.MessageContent) error {
 		user.SetNickname(rpc.Arguments[0])
 
 		showNeutralCircle := len(rpc.Arguments) < 2 || rpc.Arguments[1] != "false"
+		sliceCount := 7
+		if len(rpc.Arguments) >= 3 {
+			if n, err := strconv.Atoi(rpc.Arguments[2]); err == nil && (n == 3 || n == 7) {
+				sliceCount = n
+			}
+		}
 		_ = c.hub.WithRoom(roomID, func(room *Room) error {
 			room.showNeutralCircle = showNeutralCircle
+			room.sliceCount = sliceCount
 			return nil
 		})
 
-		reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_SPECTRUM, color, roomID, rpc.Arguments[0], "true", fmt.Sprintf("%t", showNeutralCircle))
+		reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_SPECTRUM, color, roomID, rpc.Arguments[0], "true", fmt.Sprintf("%t", showNeutralCircle), fmt.Sprintf("%d", sliceCount))
 		c.send <- reply.Export()
 	case "joinspectrum":
 		if user.IsInRoom() {
@@ -149,11 +157,13 @@ func (c *Client) EvaluateRPC(rpc *valueobjects.MessageContent) error {
 			user.SetRoom(roomID)
 
 			var roomShowNeutralCircle = true
+			var roomSliceCount = 7
 			c.hub.WithRoomRead(roomID, func(room *Room) {
 				roomShowNeutralCircle = room.showNeutralCircle
+				roomSliceCount = room.SliceCount()
 			})
 
-			reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_SPECTRUM, color, roomID, rpc.Arguments[1], "false", fmt.Sprintf("%t", roomShowNeutralCircle))
+			reply := valueobjects.NewMessageContentWithArgs(valueobjects.RPC_SPECTRUM, color, roomID, rpc.Arguments[1], "false", fmt.Sprintf("%t", roomShowNeutralCircle), fmt.Sprintf("%d", roomSliceCount))
 			c.send <- reply.Export()
 
 			if roomShowNeutralCircle {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -17,6 +17,8 @@
     "emoji": "Emoji",
     "error_no_websocket_connection": "Impossible to connect spectrum server",
     "file_spectrum": "/spectrum_en.svg",
+    "file_spectrum_3": "/spectrum_en_3.svg",
+    "spectrum_slices": "Number of slices",
     "hide_id": "Hide ID",
     "id": "ID",
     "info_definition": "Definition",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -53,6 +53,8 @@
     "mute_microphone": "Mute Microphone",
     "mute": "Mute",
     "nickname": "Nickname",
+    "your_nickname": "Your Nickname",
+    "spectrum_configuration": "Spectrum Configuration",
     "no_spectrum": "No Spectrum in progress",
     "notify_link_copied": "Link copied into the clipboard!",
     "opinion_strongly_agree": "Strongly agree",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -17,6 +17,8 @@
     "emoji": "Emoji",
     "error_no_websocket_connection": "Impossible de se connecter au serveur de spectrum",
     "file_spectrum": "/spectrum.svg",
+    "file_spectrum_3": "/spectrum_3.svg",
+    "spectrum_slices": "Nombre de cases",
     "hide_id": "Cacher l'identifiant",
     "id": "Identifiant",
     "info_definition": "Définition",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -53,6 +53,8 @@
     "mute_microphone": "Éteindre le micro",
     "mute": "Rendre muet",
     "nickname": "Pseudo",
+    "your_nickname": "Votre Pseudo",
+    "spectrum_configuration": "Configuration du Spectrum",
     "no_spectrum": "Pas de Spectrum en cours",
     "notify_link_copied": "Lien du Spectrum copié!",
     "opinion_strongly_agree": "Complètement d'accord",

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -55,6 +55,7 @@ class CanvasManager {
 	private _showNeutralCircle = true;
 	private _participantsHidden = false;
 	private _loadedSliceCount = 0;
+	private _loadingGeneration = 0;
 	private _updateIntervalId: ReturnType<typeof setInterval> | null = null;
 	private _rafId: number | null = null;
 
@@ -146,6 +147,9 @@ class CanvasManager {
 		// Skip reload if already loaded with the same slice count
 		if (this._svg && this._loadedSliceCount === sliceCount) return;
 
+		// Bump generation — any in-flight load with a different sliceCount is now stale
+		const generation = ++this._loadingGeneration;
+
 		// Remove old SVG before loading the new one
 		if (this._svg) {
 			this._canvas?.remove(this._svg);
@@ -162,6 +166,9 @@ class CanvasManager {
 			console.error('Failed to load SVG:', err);
 			return;
 		}
+
+		// Another loadSVG call was made while we were awaiting — discard this result
+		if (generation !== this._loadingGeneration) return;
 		// @ts-expect-error -- groupSVGElements return type not fully typed
 		const svg = util.groupSVGElements(objects, options);
 
@@ -498,6 +505,7 @@ class CanvasManager {
 		this._cellsPoints = [];
 		this._svg = null;
 		this._loadedSliceCount = 0;
+		this._loadingGeneration = 0;
 		this._canvas?.dispose();
 		this._canvas = null;
 		this._currentOpinion = 'notReplied';

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -164,7 +164,7 @@ class CanvasManager {
 			this._cellsPoints = [];
 		}
 
-		let objects: unknown[], options: unknown;
+		let objects: Array<{ id?: string; path?: Array<Array<number>> }>, options: unknown;
 		try {
 			const url = sliceCount === 3 ? m.file_spectrum_3() : m.file_spectrum();
 			({ objects, options } = await loadSVGFromURL(url));
@@ -195,7 +195,6 @@ class CanvasManager {
 		svg.selectable = false;
 		svg.evented = false;
 
-		// @ts-expect-error -- objects elements not fully typed
 		for (const obj of objects) {
 			if (!knownCellIds.has(obj.id)) continue;
 			this._cells.push(obj);

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -54,6 +54,7 @@ class CanvasManager {
 	private _previousOpinion = 'notReplied';
 	private _showNeutralCircle = true;
 	private _participantsHidden = false;
+	private _loadedSliceCount = 0;
 	private _updateIntervalId: ReturnType<typeof setInterval> | null = null;
 	private _rafId: number | null = null;
 
@@ -142,7 +143,10 @@ class CanvasManager {
 			'indifferent', 'notReplied'
 		]);
 
-		// Remove old SVG if reloading with a different slice count
+		// Skip reload if already loaded with the same slice count
+		if (this._svg && this._loadedSliceCount === sliceCount) return;
+
+		// Remove old SVG before loading the new one
 		if (this._svg) {
 			this._canvas?.remove(this._svg);
 			this._svg = null;
@@ -196,6 +200,7 @@ class CanvasManager {
 		}
 
 		this._svg = svg;
+		this._loadedSliceCount = sliceCount;
 		this._canvas!.add(svg);
 		this._canvas!.sendObjectToBack(svg);
 
@@ -492,6 +497,7 @@ class CanvasManager {
 		this._cells = [];
 		this._cellsPoints = [];
 		this._svg = null;
+		this._loadedSliceCount = 0;
 		this._canvas?.dispose();
 		this._canvas = null;
 		this._currentOpinion = 'notReplied';

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -135,10 +135,25 @@ class CanvasManager {
 		return canvas;
 	}
 
-	async loadSVG() {
+	async loadSVG(sliceCount = 7) {
+		const knownCellIds = new Set([
+			'disagree', 'slightlyDisagree', 'stronglyDisagree',
+			'neutral', 'slightlyAgree', 'agree', 'stronglyAgree',
+			'indifferent', 'notReplied'
+		]);
+
+		// Remove old SVG if reloading with a different slice count
+		if (this._svg) {
+			this._canvas?.remove(this._svg);
+			this._svg = null;
+			this._cells = [];
+			this._cellsPoints = [];
+		}
+
 		let objects: unknown[], options: unknown;
 		try {
-			({ objects, options } = await loadSVGFromURL(m.file_spectrum()));
+			const url = sliceCount === 3 ? m.file_spectrum_3() : m.file_spectrum();
+			({ objects, options } = await loadSVGFromURL(url));
 		} catch (err) {
 			console.error('Failed to load SVG:', err);
 			return;
@@ -163,8 +178,10 @@ class CanvasManager {
 		svg.selectable = false;
 		svg.evented = false;
 
-		for (let i = 0; i <= 8; i++) {
-			this._cells.push(objects[i]);
+		// @ts-expect-error -- objects elements not fully typed
+		for (const obj of objects) {
+			if (!knownCellIds.has(obj.id)) continue;
+			this._cells.push(obj);
 			const cell = this._cells[this._cells.length - 1];
 			this._cellsPoints[this._cells.length - 1] = [];
 
@@ -221,6 +238,7 @@ class CanvasManager {
 		for (let i = 0; i < this._cells.length; i++) {
 			const cell = this._cells[i];
 			this._cellsPoints[i] = [];
+			if (!cell?.path) continue;
 
 			for (let index = 0; index < cell.path.length - 2; index++) {
 				const pathPoint = cell.path[index];

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -139,9 +139,15 @@ class CanvasManager {
 
 	async loadSVG(sliceCount = 7) {
 		const knownCellIds = new Set([
-			'disagree', 'slightlyDisagree', 'stronglyDisagree',
-			'neutral', 'slightlyAgree', 'agree', 'stronglyAgree',
-			'indifferent', 'notReplied'
+			'disagree',
+			'slightlyDisagree',
+			'stronglyDisagree',
+			'neutral',
+			'slightlyAgree',
+			'agree',
+			'stronglyAgree',
+			'indifferent',
+			'notReplied'
 		]);
 
 		// Skip reload if already loaded with the same slice count

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -1,4 +1,4 @@
-import { Canvas, loadSVGFromURL, util } from 'fabric';
+import { Canvas, FabricObject, loadSVGFromURL, util } from 'fabric';
 import { lerp, pointInPolygon } from '$lib/utils';
 import { room, removeParticipant } from '$lib/spectrum/room.svelte';
 import { newPellet } from '$lib/canvas/pellet';
@@ -164,7 +164,7 @@ class CanvasManager {
 			this._cellsPoints = [];
 		}
 
-		let objects: Array<{ id?: string; path?: Array<Array<number>> }>, options: unknown;
+		let objects: (FabricObject | null)[], options: unknown;
 		try {
 			const url = sliceCount === 3 ? m.file_spectrum_3() : m.file_spectrum();
 			({ objects, options } = await loadSVGFromURL(url));
@@ -196,7 +196,7 @@ class CanvasManager {
 		svg.evented = false;
 
 		for (const obj of objects) {
-			if (!knownCellIds.has(obj.id)) continue;
+			if (!obj || !obj.id || !knownCellIds.has(obj.id)) continue;
 			this._cells.push(obj);
 			const cell = this._cells[this._cells.length - 1];
 			this._cellsPoints[this._cells.length - 1] = [];

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -1,4 +1,4 @@
-import { Canvas, FabricObject, loadSVGFromURL, util } from 'fabric';
+import { Canvas, loadSVGFromURL, util } from 'fabric';
 import { lerp, pointInPolygon } from '$lib/utils';
 import { room, removeParticipant } from '$lib/spectrum/room.svelte';
 import { newPellet } from '$lib/canvas/pellet';
@@ -164,7 +164,8 @@ class CanvasManager {
 			this._cellsPoints = [];
 		}
 
-		let objects: (FabricObject | null)[], options: unknown;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let objects: any[], options: unknown;
 		try {
 			const url = sliceCount === 3 ? m.file_spectrum_3() : m.file_spectrum();
 			({ objects, options } = await loadSVGFromURL(url));

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -87,7 +87,7 @@
 
 			<!-- Nombre de cases -->
 			<div class="mb-4">
-				<label class="label text-base-content font-bold">{m.spectrum_slices()}</label>
+				<span class="label text-base-content font-bold">{m.spectrum_slices()}</span>
 				<div class="flex gap-4">
 					<label class="label text-base-content cursor-pointer gap-2">
 						<input class="radio" type="radio" name="sliceCount" value={3} bind:group={sliceCount} />

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -3,7 +3,12 @@
 
 	interface ModalProps {
 		toggle: boolean;
-		onSubmit: (nickname: string, initialClaim?: string, showNeutralCircle?: boolean, sliceCount?: number) => void;
+		onSubmit: (
+			nickname: string,
+			initialClaim?: string,
+			showNeutralCircle?: boolean,
+			sliceCount?: number
+		) => void;
 	}
 
 	let { toggle = $bindable(false), onSubmit }: ModalProps = $props();
@@ -66,7 +71,9 @@
 			{/if}
 
 			<!-- Séparateur configuration -->
-			<div class="divider text-base-content/60 text-sm font-semibold">{m.spectrum_configuration()}</div>
+			<div class="divider text-base-content/60 text-sm font-semibold">
+				{m.spectrum_configuration()}
+			</div>
 
 			<!-- Claim initial -->
 			<label class="label text-base-content font-bold" for="claim">{m.initial_claim()}</label>
@@ -83,23 +90,11 @@
 				<label class="label text-base-content font-bold">{m.spectrum_slices()}</label>
 				<div class="flex gap-4">
 					<label class="label text-base-content cursor-pointer gap-2">
-						<input
-							class="radio"
-							type="radio"
-							name="sliceCount"
-							value={3}
-							bind:group={sliceCount}
-						/>
+						<input class="radio" type="radio" name="sliceCount" value={3} bind:group={sliceCount} />
 						3
 					</label>
 					<label class="label text-base-content cursor-pointer gap-2">
-						<input
-							class="radio"
-							type="radio"
-							name="sliceCount"
-							value={7}
-							bind:group={sliceCount}
-						/>
+						<input class="radio" type="radio" name="sliceCount" value={7} bind:group={sliceCount} />
 						7
 					</label>
 				</div>

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -44,9 +44,10 @@
 			>
 		</form>
 		<form class="p-4" onsubmit={handleSubmit}>
+			<!-- Pseudo -->
 			<label
 				class="label text-base-content font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
-				for="nickname2">{m.nickname()}</label
+				for="nickname2">{m.your_nickname()}</label
 			>
 			<input
 				class="input mb-1 block w-full"
@@ -58,10 +59,15 @@
 				id="nickname2"
 			/>
 			{#if errors.nickname}
-				<p class="text-error mb-3 text-sm">{m.error_field_required()}</p>
+				<p class="text-error mb-4 text-sm">{m.error_field_required()}</p>
 			{:else}
 				<div class="mb-4"></div>
 			{/if}
+
+			<!-- Séparateur configuration -->
+			<div class="divider text-base-content/60 text-sm font-semibold">{m.spectrum_configuration()}</div>
+
+			<!-- Claim initial -->
 			<label class="label text-base-content font-bold" for="claim">{m.initial_claim()}</label>
 			<input
 				class="input mb-4 block w-full"
@@ -70,19 +76,8 @@
 				id="claim"
 				bind:value={initialClaim}
 			/>
-			<div class="mb-4 flex items-center gap-2">
-				<input
-					class="checkbox"
-					type="checkbox"
-					id="showNeutralCircle"
-					bind:checked={showNeutralCircle}
-				/>
-				<label
-					class="label text-base-content cursor-pointer"
-					for="showNeutralCircle"
-					title={m.show_neutral_circle_tooltip()}>{m.show_neutral_circle()}</label
-				>
-			</div>
+
+			<!-- Nombre de cases -->
 			<div class="mb-4">
 				<label class="label text-base-content font-bold">{m.spectrum_slices()}</label>
 				<div class="flex gap-4">
@@ -108,6 +103,22 @@
 					</label>
 				</div>
 			</div>
+
+			<!-- Cercle pas répondu -->
+			<div class="mb-6 flex items-center gap-2">
+				<input
+					class="checkbox"
+					type="checkbox"
+					id="showNeutralCircle"
+					bind:checked={showNeutralCircle}
+				/>
+				<label
+					class="label text-base-content cursor-pointer"
+					for="showNeutralCircle"
+					title={m.show_neutral_circle_tooltip()}>{m.show_neutral_circle()}</label
+				>
+			</div>
+
 			<div>
 				<button class="btn btn-success float-left" type="submit">{m.start_spectrum()}</button>
 				<button class="btn btn-warning float-right" type="button" onclick={() => (toggle = false)}

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -27,7 +27,8 @@
 	let sliceCount: number = $state(7);
 	let errors = $state({ nickname: false });
 
-	function handleSubmit() {
+	function handleSubmit(e: Event) {
+		e.preventDefault();
 		errors.nickname = !nickname?.trim();
 		if (!errors.nickname) {
 			onSubmit(nickname!, initialClaim, showNeutralCircle, sliceCount);

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -91,20 +91,20 @@
 							class="radio"
 							type="radio"
 							name="sliceCount"
-							value={7}
+							value={3}
 							bind:group={sliceCount}
 						/>
-						7
+						3
 					</label>
 					<label class="label text-base-content cursor-pointer gap-2">
 						<input
 							class="radio"
 							type="radio"
 							name="sliceCount"
-							value={3}
+							value={7}
 							bind:group={sliceCount}
 						/>
-						3
+						7
 					</label>
 				</div>
 			</div>

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -3,7 +3,7 @@
 
 	interface ModalProps {
 		toggle: boolean;
-		onSubmit: (nickname: string, initialClaim?: string, showNeutralCircle?: boolean) => void;
+		onSubmit: (nickname: string, initialClaim?: string, showNeutralCircle?: boolean, sliceCount?: number) => void;
 	}
 
 	let { toggle = $bindable(false), onSubmit }: ModalProps = $props();
@@ -24,12 +24,13 @@
 	let nickname: string | undefined = $state();
 	let initialClaim: string | undefined = $state();
 	let showNeutralCircle: boolean = $state(true);
+	let sliceCount: number = $state(7);
 	let errors = $state({ nickname: false });
 
 	function handleSubmit() {
 		errors.nickname = !nickname?.trim();
 		if (!errors.nickname) {
-			onSubmit(nickname!, initialClaim, showNeutralCircle);
+			onSubmit(nickname!, initialClaim, showNeutralCircle, sliceCount);
 		}
 	}
 </script>
@@ -81,6 +82,31 @@
 					for="showNeutralCircle"
 					title={m.show_neutral_circle_tooltip()}>{m.show_neutral_circle()}</label
 				>
+			</div>
+			<div class="mb-4">
+				<label class="label text-base-content font-bold">{m.spectrum_slices()}</label>
+				<div class="flex gap-4">
+					<label class="label text-base-content cursor-pointer gap-2">
+						<input
+							class="radio"
+							type="radio"
+							name="sliceCount"
+							value={7}
+							bind:group={sliceCount}
+						/>
+						7
+					</label>
+					<label class="label text-base-content cursor-pointer gap-2">
+						<input
+							class="radio"
+							type="radio"
+							name="sliceCount"
+							value={3}
+							bind:group={sliceCount}
+						/>
+						3
+					</label>
+				</div>
 			</div>
 			<div>
 				<button class="btn btn-success float-left" type="submit">{m.start_spectrum()}</button>

--- a/frontend/src/lib/spectrum/room.svelte.ts
+++ b/frontend/src/lib/spectrum/room.svelte.ts
@@ -69,6 +69,9 @@ export const room = $state({
 	/** Whether the neutral circle (notReplied/indifferent zones) is shown on the canvas. */
 	showNeutralCircle: true,
 
+	/** Number of spectrum slices (3 or 7). */
+	sliceCount: 7,
+
 	/** True when the admin has hidden all participants from non-admins. */
 	participantsHidden: false
 });

--- a/frontend/src/lib/spectrum/room.svelte.ts
+++ b/frontend/src/lib/spectrum/room.svelte.ts
@@ -95,6 +95,7 @@ export function leaveRoom() {
 	room.listening = false;
 	room.liveChannel = undefined;
 	room.liveListening = false;
+	room.sliceCount = 7;
 	room.others = {};
 }
 

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -89,7 +89,7 @@
 			if (!canvasInitialized) {
 				canvasInitialized = true;
 				canvasManager.drawCanvas('spectrum');
-				canvasManager.loadSVG().catch(console.error);
+				canvasManager.loadSVG(room.sliceCount).catch(console.error);
 			}
 		}
 	});

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -650,6 +650,7 @@
 	) {
 		room.listening = true;
 		room.claim = initialClaim ?? '';
+		room.sliceCount = sliceCount;
 		rpc('startspectrum', nickname, showNeutralCircle.toString(), sliceCount.toString());
 		showCreateModal = false;
 		room.adminModeOn = true;

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -188,6 +188,7 @@
 			showEjectedBanner = false;
 			showJoinModal = false;
 			room.showNeutralCircle = args[4] !== 'false';
+			room.sliceCount = args[5] ? parseInt(args[5]) : 7;
 			joinRoom(args[1], args[0], args[2], args[3] == 'true');
 			joinedSpectrum(args[1]);
 			log(m.log_you_joined_spectrum(), 'join');
@@ -561,31 +562,48 @@
 	function convertVoteToPosition(vote?: number) {
 		let position;
 
-		switch (vote) {
-			case -3:
-				position = { x: 98, y: 399 };
-				break;
-			case -2:
-				position = { x: 157, y: 251 };
-				break;
-			case -1:
-				position = { x: 292, y: 127 };
-				break;
-			case 0:
-				position = { x: 475, y: 78 };
-				break;
-			case 1:
-				position = { x: 659, y: 123 };
-				break;
-			case 2:
-				position = { x: 771, y: 250 };
-				break;
-			case 3:
-				position = { x: 832, y: 408 };
-				break;
-			default:
-				position = { x: 467, y: 424 };
-				break;
+		if (room.sliceCount === 3) {
+			switch (vote) {
+				case -1:
+					position = { x: 98, y: 399 };
+					break;
+				case 0:
+					position = { x: 475, y: 78 };
+					break;
+				case 1:
+					position = { x: 832, y: 408 };
+					break;
+				default:
+					position = { x: 467, y: 424 };
+					break;
+			}
+		} else {
+			switch (vote) {
+				case -3:
+					position = { x: 98, y: 399 };
+					break;
+				case -2:
+					position = { x: 157, y: 251 };
+					break;
+				case -1:
+					position = { x: 292, y: 127 };
+					break;
+				case 0:
+					position = { x: 475, y: 78 };
+					break;
+				case 1:
+					position = { x: 659, y: 123 };
+					break;
+				case 2:
+					position = { x: 771, y: 250 };
+					break;
+				case 3:
+					position = { x: 832, y: 408 };
+					break;
+				default:
+					position = { x: 467, y: 424 };
+					break;
+			}
 		}
 
 		const randomOffsetSize = 40;
@@ -627,11 +645,12 @@
 	function onCreateSpectrum(
 		nickname: string,
 		initialClaim?: string,
-		showNeutralCircle: boolean = true
+		showNeutralCircle: boolean = true,
+		sliceCount: number = 7
 	) {
 		room.listening = true;
 		room.claim = initialClaim ?? '';
-		rpc('startspectrum', nickname, showNeutralCircle.toString());
+		rpc('startspectrum', nickname, showNeutralCircle.toString(), sliceCount.toString());
 		showCreateModal = false;
 		room.adminModeOn = true;
 		rpc('claim', room.claim);
@@ -648,6 +667,7 @@
 	function joinedSpectrum(id: string) {
 		spectrumId = id;
 
+		canvasManager.loadSVG(room.sliceCount).catch(console.error);
 		canvasManager.setNeutralCircleVisible(room.showNeutralCircle);
 
 		if (!room.adminModeOn) {

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -90,7 +90,6 @@
 				canvasInitialized = true;
 				canvasManager.drawCanvas('spectrum');
 				canvasManager.loadSVG().catch(console.error);
-				if (spectrumId) toggleJoinModal();
 			}
 		}
 	});
@@ -395,6 +394,9 @@
 
 		// Canvas is drawn in the $effect watching canvasWidth
 		// to ensure correct dimensions from the start
+
+		// Open join modal immediately if joining via URL
+		if (spectrumId) toggleJoinModal();
 	});
 
 	let showDragHint = $state(false);


### PR DESCRIPTION
## Summary

- Adds a **3 / 7 slices** radio button choice in the Create Spectrum modal
- The slice count is passed through the WebSocket RPC (`startspectrum`) and stored server-side per room, so joining users get the correct layout automatically
- Canvas loads `spectrum_3.svg` / `spectrum_en_3.svg` (or the 7-slice variants) based on the room's slice count; cell detection is now ID-based instead of a hardcoded index loop — works for any slice count
- Live vote positions remapped for 3-slice mode: `-1` disagree · `0` neutral · `1` agree

## Test plan

- [ ] Create a spectrum with 3 slices → 3-slice SVG loads, pellets snap to correct zones
- [ ] Create a spectrum with 7 slices → existing behaviour unchanged
- [ ] Join a room created with 3 slices → correct SVG and positions
- [ ] Join a room created with 7 slices → correct SVG and positions
- [ ] Live integration: send `-1`/`0`/`1` votes on a 3-slice room → pellets land in right zones
- [ ] Neutral circle toggle still works on both slice counts
- [ ] FR and EN locales both load the correct SVG file

🤖 Generated with [Claude Code](https://claude.com/claude-code)