### PR TITLE
fix: extract repeated strings to constants in utils_test.go

### DIFF
--- a/backend/utils/utils_test.go
+++ b/backend/utils/utils_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testReply = "reply"
+	testPlain = "plain"
+)
+
 func Test_computeOutput(t *testing.T) {
 	tt := map[string]struct {
 		acceptHeader []string
@@ -17,31 +22,31 @@ func Test_computeOutput(t *testing.T) {
 			acceptHeader: []string{
 				"application/json",
 			},
-			reply:    "reply",
-			plain:    "plain",
+			reply:    testReply,
+			plain:    testPlain,
 			expected: "\"reply\"",
 		},
 		"yaml": {
 			acceptHeader: []string{
 				"application/yaml",
 			},
-			reply:    "reply",
-			plain:    "plain",
+			reply:    testReply,
+			plain:    testPlain,
 			expected: "reply\n",
 		},
 		"xml": {
 			acceptHeader: []string{
 				"application/xml",
 			},
-			reply:    "reply",
-			plain:    "plain",
+			reply:    testReply,
+			plain:    testPlain,
 			expected: "<string>reply</string>",
 		},
 		"plain": {
 			acceptHeader: []string{},
-			reply:        "reply",
-			plain:        "plain",
-			expected:     "plain",
+			reply:        testReply,
+			plain:        testPlain,
+			expected:     testPlain,
 		},
 	}
 


### PR DESCRIPTION
## Summary
Fix goconst lint errors in `backend/utils/utils_test.go`:
- String `reply` used 4 times → extracted to `testReply` constant
- String `plain` used 6 times → extracted to `testPlain` constant

## Changes
- Added `const` block with `testReply` and `testPlain` constants
- Replaced all inline string occurrences in test cases

## CI
- golangci-lint `goconst` check will now pass