### PR TITLE
fix: resolve() external URL in Header + bump @sveltejs/kit

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
 				"@fortawesome/free-solid-svg-icons": "^7.2.0",
 				"@playwright/test": "^1.59.1",
 				"@sveltejs/adapter-static": "^3.0.10",
-				"@sveltejs/kit": "^2.57.1",
+				"@sveltejs/kit": "^2.59.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@tailwindcss/forms": "^0.5.11",
 				"@tailwindcss/typography": "^0.5.19",
@@ -1970,9 +1970,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.57.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
-			"integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
+			"version": "2.59.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.59.1.tgz",
+			"integrity": "sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
 		"@fortawesome/free-solid-svg-icons": "^7.2.0",
 		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.57.1",
+		"@sveltejs/kit": "^2.59.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/forms": "^0.5.11",
 		"@tailwindcss/typography": "^0.5.19",

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -107,7 +107,7 @@
 							class="link link-info"
 							target="_blank"
 							rel="noopener"
-							href={resolve(m.link_feedback_form())}>Google Form</a
+							href={m.link_feedback_form()}>Google Form</a
 						>
 					</p>
 				</div>

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -10,7 +10,6 @@
 		faSignal
 	} from '@fortawesome/free-solid-svg-icons';
 	import Fa from 'svelte-fa';
-	import { resolve } from '$app/paths';
 
 	export let title: string | undefined = undefined;
 	export let subtitle: string | undefined = undefined;


### PR DESCRIPTION
## Summary
Fix test failure in `/routes/page.svelte` after `@sveltejs/kit` 2.57.1 → 2.58.0 upgrade.

**Root cause:** `resolve()` from `@sveltejs/kit` only handles internal pathnames/route IDs. External URLs (Google Form) must be used directly.

**Fix:** Removed `resolve()` wrapper on `m.link_feedback_form()` in `Header.svelte:110`.

## Changes
- `frontend/src/lib/components/Header.svelte`: `resolve(m.link_feedback_form())` → `m.link_feedback_form()`
- Includes `@sveltejs/kit` bump from dependabot PR #471

## Testing
Tests should now pass in CI.

Closes #471