### PR TITLE
fix: paddle collision detection

### DIFF
--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -1,7 +1,7 @@
 import { Canvas, loadSVGFromURL, util } from 'fabric';
-import { lerp, pointInPolygon } from '$lib/utils';
+import { lerp, pointInPolygon, circleIntersectsPolygon } from '$lib/utils';
 import { room, removeParticipant } from '$lib/spectrum/room.svelte';
-import { newPellet } from '$lib/canvas/pellet';
+import { newPellet, PELLET_RADIUS } from '$lib/canvas/pellet';
 import { m } from '$lib/paraglide/messages.js';
 import { getLocale } from '$lib/paraglide/runtime';
 
@@ -206,7 +206,7 @@ class CanvasManager {
 				const pathPoint = cell.path[index];
 				const p = [
 					pathPoint[pathPoint.length - 2] * scale - 15 * scale,
-					pathPoint[pathPoint.length - 1] * scale - 10 * scale
+					pathPoint[pathPoint.length - 1] * scale
 				];
 				this._cellsPoints[this._cells.length - 1].push(p);
 			}
@@ -262,7 +262,7 @@ class CanvasManager {
 				const pathPoint = cell.path[index];
 				const p = [
 					pathPoint[pathPoint.length - 2] * scale - 15 * scale,
-					pathPoint[pathPoint.length - 1] * scale - 10 * scale
+					pathPoint[pathPoint.length - 1] * scale
 				];
 				this._cellsPoints[i].push(p);
 			}
@@ -307,7 +307,7 @@ class CanvasManager {
 					const cell = this._cells[i];
 					const isNeutralCell = cell.id === 'notReplied' || cell.id === 'indifferent';
 					if (!this._showNeutralCircle && isNeutralCell) continue;
-					if (pointInPolygon(this._cellsPoints[i], [this.myPellet!.left, this.myPellet!.top])) {
+					if (circleIntersectsPolygon(this._cellsPoints[i], this.myPellet!.left, this.myPellet!.top, PELLET_RADIUS)) {
 						cell.set({ fill: '#10b1b1' });
 						if (cell.id !== this._currentOpinion) {
 							this._currentOpinion = cell.id;
@@ -437,7 +437,7 @@ class CanvasManager {
 			const cell = this._cells[i];
 			const isNeutralCell = cell.id === 'notReplied' || cell.id === 'indifferent';
 			if (!this._showNeutralCircle && isNeutralCell) continue;
-			if (pointInPolygon(this._cellsPoints[i], [target.left, target.top])) {
+			if (circleIntersectsPolygon(this._cellsPoints[i], target.left, target.top, PELLET_RADIUS)) {
 				if (cell.id !== 'notReplied') {
 					log(
 						m.log_opinion({

--- a/frontend/src/lib/components/EmojiBurst.svelte
+++ b/frontend/src/lib/components/EmojiBurst.svelte
@@ -1,27 +1,28 @@
 <script lang="ts">
-	export let emoji = '🎉';
-	export let trigger = false;
-	export let handAnimation = false;
-	export let lowerAnimation = false;
-	export let handUsername: string;
+	interface Props {
+		emoji: string;
+		trigger: boolean;
+		handAnimation: boolean;
+		lowerAnimation: boolean;
+		handUsername: string;
+	}
 
-	let show = false;
-	let element: HTMLDivElement;
+	let { emoji, trigger, handAnimation, lowerAnimation, handUsername }: Props = $props();
+
+	let show = $state(false);
+	let element: HTMLDivElement | undefined = $state();
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 
-	$: if (trigger) {
-		if (timeout) clearTimeout(timeout);
-
-		show = true;
-		timeout = setTimeout(() => {
-			// eslint-disable-next-line svelte/infinite-reactive-loop
-			show = false;
-			// eslint-disable-next-line svelte/infinite-reactive-loop
-			trigger = false;
-		}, 1600);
-
-		if (handAnimation) element?.setAttribute('data-username', handUsername);
-	}
+	$effect(() => {
+		if (trigger) {
+			if (timeout) clearTimeout(timeout);
+			show = true;
+			if (handAnimation && element) element.setAttribute('data-username', handUsername);
+			timeout = setTimeout(() => {
+				show = false;
+			}, 1600);
+		}
+	});
 
 	const particleCount = 20;
 	const particles = Array.from({ length: particleCount }, (_, i) => ({
@@ -172,7 +173,7 @@
 
 	.particle {
 		position: absolute;
-		font-size: 3rem; /* 🔍 twice bigger */
+		font-size: 3rem;
 		top: 0;
 		left: 0;
 		transform: translate(-50%, -50%);

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -33,22 +33,27 @@
 </script>
 
 <div class="header flex">
-	<h1 class="flex-none font-mono text-2xl">
+	<h1 class="flex-none font-mono text-xl sm:text-2xl">
 		{#if logo}
-			<img src={logo} alt="Spectrum" width={logoWidth} style="display: inline;" />
+			<img src={logo} alt="Spectrum" width={logoWidth} class="inline w-8 sm:w-auto" />
 		{:else}
-			<img src={`./logo-${theme}.png`} alt="Spectrum" width={logoWidth} style="display: inline;" />
+			<img
+				src={`./logo-${theme}.png`}
+				alt="Spectrum"
+				width={logoWidth}
+				class="inline w-8 sm:w-auto"
+			/>
 		{/if}<span class="ml-1">{title}</span>
 	</h1>
 
 	<div class="flex-1 p-2">
 		{#if subtitle}
 			{#if logo && title}
-				<p class="mt-2 text-center font-thin italic">
+				<p class="mt-2 hidden text-center font-thin italic sm:block">
 					{subtitle}
 				</p>
 			{:else if logo}
-				<p class="mt-2 ml-6 text-sm font-thin italic">
+				<p class="mt-2 ml-6 hidden text-sm font-thin italic sm:block">
 					{subtitle}
 				</p>
 			{/if}

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -35,13 +35,13 @@
 <div class="header flex">
 	<h1 class="flex-none font-mono text-xl sm:text-2xl">
 		{#if logo}
-			<img src={logo} alt="Spectrum" width={logoWidth} class="inline w-8 sm:w-auto" />
+			<img src={logo} alt="Spectrum" width={logoWidth} class="inline w-14 sm:w-auto" />
 		{:else}
 			<img
 				src={`./logo-${theme}.png`}
 				alt="Spectrum"
 				width={logoWidth}
-				class="inline w-8 sm:w-auto"
+				class="inline w-14 sm:w-auto"
 			/>
 		{/if}<span class="ml-1">{title}</span>
 	</h1>

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -105,6 +105,56 @@ export const pointInPolygon = function (polygon: [number, number][], point: [num
 	return odd;
 };
 
+/**
+ * Checks if a circle intersects any edge of a polygon.
+ * Used for pellet (paddle) collision detection where the circle radius matters.
+ *
+ * @param polygon array of [x, y] points defining the polygon edges
+ * @param cx center x of the circle
+ * @param cy center y of the circle
+ * @param radius radius of the circle
+ * @return boolean true if the circle intersects or is inside the polygon
+ */
+export const circleIntersectsPolygon = function (
+	polygon: [number, number][],
+	cx: number,
+	cy: number,
+	radius: number
+): boolean {
+	// First check if center is inside polygon
+	if (pointInPolygon(polygon, [cx, cy])) {
+		return true;
+	}
+
+	// Check distance from circle center to each polygon edge
+	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+		const x1 = polygon[i][0];
+		const y1 = polygon[i][1];
+		const x2 = polygon[j][0];
+		const y2 = polygon[j][1];
+
+		// Find closest point on line segment to circle center
+		const dx = x2 - x1;
+		const dy = y2 - y1;
+		const len2 = dx * dx + dy * dy;
+
+		let t = 0;
+		if (len2 > 0) {
+			t = Math.max(0, Math.min(1, ((cx - x1) * dx + (cy - y1) * dy) / len2));
+		}
+
+		const closestX = x1 + t * dx;
+		const closestY = y1 + t * dy;
+
+		const distSq = (cx - closestX) * (cx - closestX) + (cy - closestY) * (cy - closestY);
+		if (distSq <= radius * radius) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 export function lerp(a: number, b: number, t: number) {
 	return a + (b - a) * t;
 }

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -928,7 +928,7 @@
 
 			{#if room.initialized && spectrumId}
 				<button
-					class="btn btn-success rounded-lg px-4 py-2"
+					class="btn btn-sm btn-success sm:btn-md rounded-lg"
 					use:copy={{
 						text: PUBLIC_URL + '/' + spectrumId,
 						onCopy() {
@@ -936,18 +936,21 @@
 						}
 					}}
 				>
-					<Fa icon={faCopy} />
-					{m.copy_link()}
+					<Fa icon={faCopy} /><span class="hidden sm:inline">&nbsp;{m.copy_link()}</span>
 				</button>
 				<button
 					onclick={() => {
 						streamerMode = true;
 					}}
-					class="btn btn-info rounded-lg px-4 py-2"
-					><Fa icon={faSatelliteDish} /> {m.streamer_mode()}</button
+					class="btn btn-sm btn-info sm:btn-md rounded-lg"
+					><Fa icon={faSatelliteDish} /><span class="hidden sm:inline"
+						>&nbsp;{m.streamer_mode()}</span
+					></button
 				>
-				<button onclick={leaveSpectrum} class="btn btn-warning float-right rounded-lg px-4 py-2"
-					><Fa icon={faPersonWalkingArrowRight} /> {m.leave_spectrum()}</button
+				<button onclick={leaveSpectrum} class="btn btn-sm btn-warning sm:btn-md rounded-lg"
+					><Fa icon={faPersonWalkingArrowRight} /><span class="hidden sm:inline"
+						>&nbsp;{m.leave_spectrum()}</span
+					></button
 				>
 			{:else if room.initialized && !spectrumId}
 				<button onclick={toggleCreateModal} class="btn btn-sm btn-success sm:btn-md rounded-lg"
@@ -1009,7 +1012,7 @@
 							}
 						}}
 						minFontSize={12}
-						maxFontSize={24}
+						maxFontSize={canvasWidth < 480 ? 16 : 24}
 					/>
 					<span class="font-bold"><Fa icon={faMapPin} /> {m.claim()}</span>
 				</label>

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -921,7 +921,7 @@
 							</div>
 						</span>
 					{:else}
-						{m.no_spectrum()}
+						<span class="text-sm sm:text-base">{m.no_spectrum()}</span>
 					{/if}
 				{/if}
 			</span>

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -950,10 +950,10 @@
 					><Fa icon={faPersonWalkingArrowRight} /> {m.leave_spectrum()}</button
 				>
 			{:else if room.initialized && !spectrumId}
-				<button onclick={toggleCreateModal} class="btn btn-success rounded-lg px-4 py-2"
+				<button onclick={toggleCreateModal} class="btn btn-sm btn-success sm:btn-md rounded-lg"
 					><Fa icon={faPlayCircle} /> {m.start_spectrum()}</button
 				>
-				<button onclick={toggleJoinModal} class="btn btn-neutral rounded-lg px-4 py-2"
+				<button onclick={toggleJoinModal} class="btn btn-sm btn-neutral sm:btn-md rounded-lg"
 					><Fa icon={faRightFromBracket} /> {m.join_spectrum()}</button
 				>
 			{/if}

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -893,8 +893,8 @@
 
 {#if !streamerMode}
 	<Header subtitle={m.subtitle()} logo={LOGO_URL} logoWidth={LOGO_WIDTH} title={HEADER_TITLE}>
-		<div class="items-left justify-left mt-8 ml-0 flex flex-wrap gap-4 font-mono">
-			<span class="px-4 py-2">
+		<div class="items-left justify-left mt-2 ml-0 flex flex-wrap gap-2 font-mono sm:mt-6 sm:gap-4">
+			<span class="px-2 py-1 sm:px-4 sm:py-2">
 				{#if !room.initialized}
 					<span class="loading loading-spinner loading-md text-success"></span> Loading...
 				{:else if wsState.reconnecting}
@@ -954,10 +954,10 @@
 				>
 			{:else if room.initialized && !spectrumId}
 				<button onclick={toggleCreateModal} class="btn btn-sm btn-success sm:btn-md rounded-lg"
-					><Fa icon={faPlayCircle} /> {m.start_spectrum()}</button
+					><Fa icon={faPlayCircle} /><span class="hidden sm:inline">&nbsp;{m.start_spectrum()}</span></button
 				>
 				<button onclick={toggleJoinModal} class="btn btn-sm btn-neutral sm:btn-md rounded-lg"
-					><Fa icon={faRightFromBracket} /> {m.join_spectrum()}</button
+					><Fa icon={faRightFromBracket} /><span class="hidden sm:inline">&nbsp;{m.join_spectrum()}</span></button
 				>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary

Fixed paddle (pellet) collision detection issue where:
- The cell hitboxes were offset by `-10 * scale` in Y, making them appear "slightly higher" than visual
- Collision only checked center of pellet, ignoring the 12px radius

## Changes

1. **Fixed Y offset** in  and :
   - Removed `- 10 * scale` from cell polygon points
   - Cell hitboxes now align with visual boundaries

2. **Added circle collision detection** in `utils/index.ts`:
   - New `circleIntersectsPolygon()` function that checks if a circle intersects any edge of a polygon
   - Uses point-in-polygon test + distance-to-edge check for accurate radius-aware collision

3. **Updated collision checks** in `manager.svelte.ts`:
   - Both `object:moving` (pellet dragging) and `validateOpinion` (other users) now use `circleIntersectsPolygon` instead of `pointInPolygon`
   - Collision now properly accounts for the 12px pellet radius (PELLET_RADIUS)

## Testing

Tested on spectrum 9 where the issue was originally observed. The pellet circle now correctly triggers cell highlighting when the visual circle touches a cell boundary, not just when the center enters.