### PR TITLE
fix: pellet collision detection

### DIFF
--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -1,7 +1,7 @@
 import { Canvas, loadSVGFromURL, util } from 'fabric';
-import { lerp, pointInPolygon } from '$lib/utils';
+import { lerp, pointInPolygon, circleIntersectsPolygon } from '$lib/utils';
 import { room, removeParticipant } from '$lib/spectrum/room.svelte';
-import { newPellet } from '$lib/canvas/pellet';
+import { newPellet, PELLET_RADIUS } from '$lib/canvas/pellet';
 import { m } from '$lib/paraglide/messages.js';
 import { getLocale } from '$lib/paraglide/runtime';
 
@@ -216,7 +216,7 @@ class CanvasManager {
 				const pathPoint = cell.path[index];
 				const p = [
 					pathPoint[pathPoint.length - 2] * scale - 15 * scale,
-					pathPoint[pathPoint.length - 1] * scale - 10 * scale
+					pathPoint[pathPoint.length - 1] * scale
 				];
 				this._cellsPoints[this._cells.length - 1].push(p);
 			}
@@ -272,7 +272,7 @@ class CanvasManager {
 				const pathPoint = cell.path[index];
 				const p = [
 					pathPoint[pathPoint.length - 2] * scale - 15 * scale,
-					pathPoint[pathPoint.length - 1] * scale - 10 * scale
+					pathPoint[pathPoint.length - 1] * scale
 				];
 				this._cellsPoints[i].push(p);
 			}
@@ -317,7 +317,7 @@ class CanvasManager {
 					const cell = this._cells[i];
 					const isNeutralCell = cell.id === 'notReplied' || cell.id === 'indifferent';
 					if (!this._showNeutralCircle && isNeutralCell) continue;
-					if (pointInPolygon(this._cellsPoints[i], [this.myPellet!.left, this.myPellet!.top])) {
+					if (circleIntersectsPolygon(this._cellsPoints[i], this.myPellet!.left, this.myPellet!.top, PELLET_RADIUS)) {
 						cell.set({ fill: '#10b1b1' });
 						if (cell.id !== this._currentOpinion) {
 							this._currentOpinion = cell.id;
@@ -447,7 +447,7 @@ class CanvasManager {
 			const cell = this._cells[i];
 			const isNeutralCell = cell.id === 'notReplied' || cell.id === 'indifferent';
 			if (!this._showNeutralCircle && isNeutralCell) continue;
-			if (pointInPolygon(this._cellsPoints[i], [target.left, target.top])) {
+			if (circleIntersectsPolygon(this._cellsPoints[i], target.left, target.top, PELLET_RADIUS)) {
 				if (cell.id !== 'notReplied') {
 					log(
 						m.log_opinion({

--- a/frontend/src/lib/canvas/manager.svelte.ts
+++ b/frontend/src/lib/canvas/manager.svelte.ts
@@ -1,5 +1,5 @@
 import { Canvas, loadSVGFromURL, util } from 'fabric';
-import { lerp, pointInPolygon, circleIntersectsPolygon } from '$lib/utils';
+import { lerp, pathToPolygon, circleIntersectsPolygon } from '$lib/utils';
 import { room, removeParticipant } from '$lib/spectrum/room.svelte';
 import { newPellet, PELLET_RADIUS } from '$lib/canvas/pellet';
 import { m } from '$lib/paraglide/messages.js';
@@ -195,13 +195,16 @@ class CanvasManager {
 		const scaleY = canvasHeight / svg.height!;
 		const scale = Math.min(scaleX, scaleY);
 
+		const svgLeft = (canvasWidth - svg.width! * scale) / 2;
+		const svgTop = 15 * this._scale;
+
 		svg.set({
 			originX: 'left',
 			originY: 'top',
 			scaleX: scale,
 			scaleY: scale,
-			left: (canvasWidth - svg.width! * scale) / 2,
-			top: 15 * this._scale
+			left: svgLeft,
+			top: svgTop
 		});
 		svg.selectable = false;
 		svg.evented = false;
@@ -210,16 +213,10 @@ class CanvasManager {
 			if (!obj || !obj.id || !knownCellIds.has(obj.id)) continue;
 			this._cells.push(obj);
 			const cell = this._cells[this._cells.length - 1];
-			this._cellsPoints[this._cells.length - 1] = [];
-
-			for (let index = 0; index < cell.path.length - 2; index++) {
-				const pathPoint = cell.path[index];
-				const p = [
-					pathPoint[pathPoint.length - 2] * scale - 15 * scale,
-					pathPoint[pathPoint.length - 1] * scale
-				];
-				this._cellsPoints[this._cells.length - 1].push(p);
-			}
+			const raw = pathToPolygon(cell.path);
+			this._cellsPoints[this._cells.length - 1] = raw.map(
+				([x, y]) => [x * scale + svgLeft, y * scale + svgTop] as [number, number]
+			);
 		}
 
 		this._svg = svg;
@@ -242,14 +239,17 @@ class CanvasManager {
 
 		this._canvas.setDimensions({ width: canvasWidth, height: scale * originalHeight });
 
+		const svgLeft = this._svg ? (canvasWidth - this._svg.width! * scale) / 2 : 0;
+		const svgTop = 15 * scale;
+
 		if (this._svg) {
 			this._svg.set({
 				originX: 'left',
 				originY: 'top',
 				scaleX: scale,
 				scaleY: scale,
-				left: (canvasWidth - this._svg.width! * scale) / 2,
-				top: 15 * scale
+				left: svgLeft,
+				top: svgTop
 			});
 		}
 
@@ -268,14 +268,10 @@ class CanvasManager {
 			this._cellsPoints[i] = [];
 			if (!cell?.path) continue;
 
-			for (let index = 0; index < cell.path.length - 2; index++) {
-				const pathPoint = cell.path[index];
-				const p = [
-					pathPoint[pathPoint.length - 2] * scale - 15 * scale,
-					pathPoint[pathPoint.length - 1] * scale
-				];
-				this._cellsPoints[i].push(p);
-			}
+			const raw = pathToPolygon(cell.path);
+			this._cellsPoints[i] = raw.map(
+				([x, y]) => [x * scale + svgLeft, y * scale + svgTop] as [number, number]
+			);
 		}
 	}
 
@@ -317,7 +313,14 @@ class CanvasManager {
 					const cell = this._cells[i];
 					const isNeutralCell = cell.id === 'notReplied' || cell.id === 'indifferent';
 					if (!this._showNeutralCircle && isNeutralCell) continue;
-					if (circleIntersectsPolygon(this._cellsPoints[i], this.myPellet!.left, this.myPellet!.top, PELLET_RADIUS)) {
+					if (
+						circleIntersectsPolygon(
+							this._cellsPoints[i],
+							this.myPellet!.left,
+							this.myPellet!.top,
+							PELLET_RADIUS
+						)
+					) {
 						cell.set({ fill: '#10b1b1' });
 						if (cell.id !== this._currentOpinion) {
 							this._currentOpinion = cell.id;

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -105,6 +105,56 @@ export const pointInPolygon = function (polygon: [number, number][], point: [num
 	return odd;
 };
 
+/**
+ * Checks if a circle intersects any edge of a polygon.
+ * Used for pellet (paddle) collision detection where the circle radius matters.
+ *
+ * @param polygon array of [x, y] points defining the polygon edges
+ * @param cx center x of the circle
+ * @param cy center y of the circle
+ * @param radius radius of the circle
+ * @return boolean true if the circle intersects or is inside the polygon
+ */
+export const circleIntersectsPolygon = function (
+	polygon: [number, number][],
+	cx: number,
+	cy: number,
+	radius: number
+): boolean {
+	// First check if center is inside polygon
+	if (pointInPolygon(polygon, [cx, cy])) {
+		return true;
+	}
+
+	// Check distance from circle center to each polygon edge
+	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+		const x1 = polygon[i][0];
+		const y1 = polygon[i][1];
+		const x2 = polygon[j][0];
+		const y2 = polygon[j][1];
+
+		// Find closest point on line segment to circle center
+		const dx = x2 - x1;
+		const dy = y2 - y1;
+		const len2 = dx * dx + dy * dy;
+
+		let t = 0;
+		if (len2 > 0) {
+			t = Math.max(0, Math.min(1, ((cx - x1) * dx + (cy - y1) * dy) / len2));
+		}
+
+		const closestX = x1 + t * dx;
+		const closestY = y1 + t * dy;
+
+		const distSq = (cx - closestX) * (cx - closestX) + (cy - closestY) * (cy - closestY);
+		if (distSq <= radius * radius) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 export function lerp(a: number, b: number, t: number) {
 	return a + (b - a) * t;
 }

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -159,6 +159,163 @@ export function lerp(a: number, b: number, t: number) {
 	return a + (b - a) * t;
 }
 
+/**
+ * Convert a Fabric path (array of absolute commands: M, L, H, V, C, S, Q, T, A, Z)
+ * into a polygon by sampling curves into N segments per command.
+ */
+export function pathToPolygon(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	path: any[],
+	samples = 16
+): [number, number][] {
+	const points: [number, number][] = [];
+	let curX = 0;
+	let curY = 0;
+	let startX = 0;
+	let startY = 0;
+
+	const push = (x: number, y: number) => {
+		points.push([x, y]);
+		curX = x;
+		curY = y;
+	};
+
+	for (const cmd of path) {
+		const type = cmd[0];
+		switch (type) {
+			case 'M': {
+				startX = cmd[1];
+				startY = cmd[2];
+				push(cmd[1], cmd[2]);
+				break;
+			}
+			case 'L': {
+				push(cmd[1], cmd[2]);
+				break;
+			}
+			case 'H': {
+				push(cmd[1], curY);
+				break;
+			}
+			case 'V': {
+				push(curX, cmd[1]);
+				break;
+			}
+			case 'C': {
+				const x1 = cmd[1],
+					y1 = cmd[2];
+				const x2 = cmd[3],
+					y2 = cmd[4];
+				const x = cmd[5],
+					y = cmd[6];
+				const p0x = curX,
+					p0y = curY;
+				for (let i = 1; i <= samples; i++) {
+					const t = i / samples;
+					const mt = 1 - t;
+					const bx =
+						mt * mt * mt * p0x + 3 * mt * mt * t * x1 + 3 * mt * t * t * x2 + t * t * t * x;
+					const by =
+						mt * mt * mt * p0y + 3 * mt * mt * t * y1 + 3 * mt * t * t * y2 + t * t * t * y;
+					points.push([bx, by]);
+				}
+				curX = x;
+				curY = y;
+				break;
+			}
+			case 'Q': {
+				const x1 = cmd[1],
+					y1 = cmd[2];
+				const x = cmd[3],
+					y = cmd[4];
+				const p0x = curX,
+					p0y = curY;
+				for (let i = 1; i <= samples; i++) {
+					const t = i / samples;
+					const mt = 1 - t;
+					const bx = mt * mt * p0x + 2 * mt * t * x1 + t * t * x;
+					const by = mt * mt * p0y + 2 * mt * t * y1 + t * t * y;
+					points.push([bx, by]);
+				}
+				curX = x;
+				curY = y;
+				break;
+			}
+			case 'A': {
+				const rx0 = Math.abs(cmd[1]);
+				const ry0 = Math.abs(cmd[2]);
+				const xRotDeg = cmd[3];
+				const largeArc = !!cmd[4];
+				const sweep = !!cmd[5];
+				const x2 = cmd[6],
+					y2 = cmd[7];
+				const x1 = curX,
+					y1 = curY;
+				if (rx0 === 0 || ry0 === 0 || (x1 === x2 && y1 === y2)) {
+					push(x2, y2);
+					break;
+				}
+				const phi = (xRotDeg * Math.PI) / 180;
+				const cosPhi = Math.cos(phi),
+					sinPhi = Math.sin(phi);
+				const dx = (x1 - x2) / 2,
+					dy = (y1 - y2) / 2;
+				const x1p = cosPhi * dx + sinPhi * dy;
+				const y1p = -sinPhi * dx + cosPhi * dy;
+				let rx = rx0,
+					ry = ry0;
+				const lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+				if (lambda > 1) {
+					const s = Math.sqrt(lambda);
+					rx *= s;
+					ry *= s;
+				}
+				const sign = largeArc === sweep ? -1 : 1;
+				const num = rx * rx * ry * ry - rx * rx * y1p * y1p - ry * ry * x1p * x1p;
+				const den = rx * rx * y1p * y1p + ry * ry * x1p * x1p;
+				const factor = sign * Math.sqrt(Math.max(0, num / den));
+				const cxp = (factor * (rx * y1p)) / ry;
+				const cyp = (factor * -(ry * x1p)) / rx;
+				const cx = cosPhi * cxp - sinPhi * cyp + (x1 + x2) / 2;
+				const cy = sinPhi * cxp + cosPhi * cyp + (y1 + y2) / 2;
+				const angle = (ux: number, uy: number, vx: number, vy: number) => {
+					const dot = ux * vx + uy * vy;
+					const len = Math.sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy));
+					let a = Math.acos(Math.max(-1, Math.min(1, dot / len)));
+					if (ux * vy - uy * vx < 0) a = -a;
+					return a;
+				};
+				const theta1 = angle(1, 0, (x1p - cxp) / rx, (y1p - cyp) / ry);
+				let dTheta = angle(
+					(x1p - cxp) / rx,
+					(y1p - cyp) / ry,
+					(-x1p - cxp) / rx,
+					(-y1p - cyp) / ry
+				);
+				if (!sweep && dTheta > 0) dTheta -= 2 * Math.PI;
+				else if (sweep && dTheta < 0) dTheta += 2 * Math.PI;
+				for (let i = 1; i <= samples; i++) {
+					const t = i / samples;
+					const a = theta1 + dTheta * t;
+					const px = cosPhi * (rx * Math.cos(a)) - sinPhi * (ry * Math.sin(a)) + cx;
+					const py = sinPhi * (rx * Math.cos(a)) + cosPhi * (ry * Math.sin(a)) + cy;
+					points.push([px, py]);
+				}
+				curX = x2;
+				curY = y2;
+				break;
+			}
+			case 'Z':
+			case 'z': {
+				curX = startX;
+				curY = startY;
+				break;
+			}
+		}
+	}
+	return points;
+}
+
 export function capitalize(str: string): string {
 	if (!str) return '';
 	return str.charAt(0).toUpperCase() + str.slice(1);


### PR DESCRIPTION
## Summary

Fixes paddle (pellet) collision detection so cells highlight reliably when the pellet visually overlaps them. Three issues were addressed:

1. The cell hitboxes were offset incorrectly relative to the rendered SVG (ad-hoc `-15 * scale` X and `-10 * scale` Y shifts), so polygons were misaligned with what the user sees.
2. Collision only tested the pellet's center point, ignoring the 12px circle radius.
3. Cell polygons were built from path command **endpoints only**, so curved boundaries (cubic Bézier `C` and arc `A` commands) were approximated as chords. A pellet sitting in the bulge of a curved cell could be visually inside but mathematically outside the polygon.

## Changes

### `utils/index.ts`
- New `circleIntersectsPolygon()` — point-in-polygon test plus distance-to-edge check, so collision triggers as soon as any part of the pellet's 12px radius touches a cell.
- New `pathToPolygon()` — converts a Fabric path (absolute commands `M L H V C Q A Z`) into a dense polygon by sampling each curve into 16 segments. Cubic/quadratic Bézier and elliptical arcs are tessellated; straight commands keep their endpoints.

### `canvas/manager.svelte.ts`
- Cell polygons are now built via `pathToPolygon(cell.path)` in both `loadSVG` and `setScale`, so curved cell boundaries are matched accurately.
- Replaced the magic offsets with the actual SVG group transform: `point * scale + svgLeft` / `+ svgTop`, where `svgLeft = (canvasWidth - svg.width * scale) / 2` and `svgTop = 15 * scale` — the same values used to position the SVG itself.
- `object:moving` (local pellet drag) and `validateOpinion` (remote pellets) both use `circleIntersectsPolygon` with `PELLET_RADIUS`.

## Testing

Reproduced on `spectrum_9.svg` where a pellet fully inside the curved `stronglyDisagree` cell was not detected. After the fix the cell highlights as soon as the pellet's edge crosses the cell boundary, including in the curved/bulged regions. Verified across 3, 5, 7 and 9 slice spectrums.