### PR TITLE
refactor(welcome): unify modal pattern with native <dialog>

### DIFF
--- a/frontend/src/lib/components/WelcomePane.svelte
+++ b/frontend/src/lib/components/WelcomePane.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
+	import { getLocale, setLocale } from '$lib/paraglide/runtime';
 	import { LOGO_URL, LOGO_WIDTH } from '$lib/env';
 	import Fa from 'svelte-fa';
-	import { faPlayCircle, faRightFromBracket } from '@fortawesome/free-solid-svg-icons';
+	import {
+		faGlobe,
+		faPlayCircle,
+		faRightFromBracket
+	} from '@fortawesome/free-solid-svg-icons';
 
 	let {
 		onStart,
@@ -15,17 +20,56 @@
 		ready: boolean;
 		reconnecting: boolean;
 	} = $props();
+
+	const modalId = 'welcome-modal';
+
+	$effect(() => {
+		const el = document.getElementById(modalId);
+		if (el instanceof HTMLDialogElement && !el.open) {
+			el.showModal();
+		}
+	});
+
+	function pickLocale(locale: 'en' | 'fr', event: Event) {
+		setLocale(locale);
+		(event.currentTarget as HTMLElement)
+			.closest('details')
+			?.removeAttribute('open');
+	}
 </script>
 
-<div
-	class="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4"
+<dialog
+	id={modalId}
+	class="modal"
 	aria-label={m.welcome_title()}
-	role="dialog"
-	aria-modal="true"
+	oncancel={(e) => e.preventDefault()}
 >
-	<section
-		class="bg-base-100 flex w-full max-w-xl flex-col items-center gap-6 rounded-xl p-6 shadow-2xl sm:p-8"
-	>
+	<div class="modal-box relative flex flex-col items-center gap-6 p-4 sm:p-6 md:p-8">
+		<!-- Language switcher (always reachable since the modal is non-dismissable) -->
+		<details class="dropdown dropdown-end absolute top-2 right-2">
+			<summary class="btn btn-ghost btn-sm" aria-label="Languages">
+				<Fa icon={faGlobe} class="text-base" />
+			</summary>
+			<ul class="dropdown-content menu bg-base-100 rounded-box z-1 mt-1 w-40 p-2 shadow-sm">
+				<li>
+					<button class:menu-active={getLocale() === 'en'} onclick={(e) => pickLocale('en', e)}>
+						<span class="pe-2 font-mono text-[.5625rem] font-bold tracking-[0.09375rem] opacity-40"
+							>EN</span
+						>
+						<span class="font-[sans-serif]">English</span>
+					</button>
+				</li>
+				<li>
+					<button class:menu-active={getLocale() === 'fr'} onclick={(e) => pickLocale('fr', e)}>
+						<span class="pe-2 font-mono text-[.5625rem] font-bold tracking-[0.09375rem] opacity-40"
+							>FR</span
+						>
+						<span class="font-[sans-serif]">Français</span>
+					</button>
+				</li>
+			</ul>
+		</details>
+
 		<div class="flex flex-col items-center gap-4">
 			<img
 				src={LOGO_URL ?? './logo-light.png'}
@@ -45,12 +89,12 @@
 			class="flex min-h-16 w-full flex-col items-stretch justify-center gap-4 sm:flex-row sm:flex-wrap sm:items-center"
 		>
 			{#if !ready}
-				<span class="font-mono text-sm">
+				<span class="text-center font-mono text-sm">
 					<span class="loading loading-spinner loading-md text-success"></span>
 					&nbsp;Loading...
 				</span>
 			{:else if reconnecting}
-				<span class="font-mono text-sm">
+				<span class="text-center font-mono text-sm">
 					<span class="loading loading-spinner loading-sm text-warning"></span>
 					<span class="text-warning">&nbsp;Reconnecting...</span>
 				</span>
@@ -63,22 +107,5 @@
 				</button>
 			{/if}
 		</div>
-	</section>
-</div>
-
-<style>
-	section {
-		animation: welcome-fadein 0.4s ease forwards;
-	}
-
-	@keyframes welcome-fadein {
-		from {
-			opacity: 0;
-			transform: translateY(-8px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
-</style>
+	</div>
+</dialog>

--- a/frontend/src/lib/components/WelcomePane.svelte
+++ b/frontend/src/lib/components/WelcomePane.svelte
@@ -21,7 +21,7 @@
 
 	$effect(() => {
 		const el = document.getElementById(modalId);
-		if (el instanceof HTMLDialogElement && !el.open) {
+		if (el instanceof HTMLDialogElement && !el.open && typeof el.showModal === 'function') {
 			el.showModal();
 		}
 	});

--- a/frontend/src/lib/components/WelcomePane.svelte
+++ b/frontend/src/lib/components/WelcomePane.svelte
@@ -3,11 +3,7 @@
 	import { getLocale, setLocale } from '$lib/paraglide/runtime';
 	import { LOGO_URL, LOGO_WIDTH } from '$lib/env';
 	import Fa from 'svelte-fa';
-	import {
-		faGlobe,
-		faPlayCircle,
-		faRightFromBracket
-	} from '@fortawesome/free-solid-svg-icons';
+	import { faGlobe, faPlayCircle, faRightFromBracket } from '@fortawesome/free-solid-svg-icons';
 
 	let {
 		onStart,
@@ -32,9 +28,7 @@
 
 	function pickLocale(locale: 'en' | 'fr', event: Event) {
 		setLocale(locale);
-		(event.currentTarget as HTMLElement)
-			.closest('details')
-			?.removeAttribute('open');
+		(event.currentTarget as HTMLElement).closest('details')?.removeAttribute('open');
 	}
 </script>
 

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -862,7 +862,7 @@
 <EmojiBurst {emoji} {trigger} {handAnimation} {lowerAnimation} {handUsername} />
 
 {#if !streamerMode}
-	<div class="relative z-50 flex-none">
+	<div class="relative z-30 flex-none">
 		<Header
 			subtitle={m.subtitle()}
 			logo={LOGO_URL}


### PR DESCRIPTION
## Summary
- Migrate `WelcomePane` from a custom `fixed inset-0 + bg-black/50` overlay to the native `<dialog class="modal">` + `modal-box` pattern used by the four existing modals (Create / Join / ConnectLive / AddLiveUserParticipant).
- Add a compact language selector (globe icon, top-right of the modal-box) so users can still switch language from the welcome screen — necessary because `.showModal()` puts the dialog in the top layer and the header is no longer reachable while it is up.
- Use `<details>`/`<summary>` for the language dropdown so it does not auto-open when the dialog focuses its first focusable child.
- Prevent the `cancel` event so escape can not dismiss the welcome screen (matching prior non-dismissable behavior).
- Revert the page header wrapper z-index from `z-50` back to `z-30` (the bump was a workaround for the previous custom overlay).

## Why
First item from the milestone 1.2 UI/UX coherence audit. Two modal mechanisms coexisted in the codebase — this aligns the welcome screen with the rest.

## Test plan
- [ ] First load (no spectrum, no localStorage state): welcome modal appears immediately with spinner, then resolves to Start / Join buttons once the WS connects.
- [ ] Language dropdown stays closed when the modal opens.
- [ ] Click the globe → language list opens; pick FR or EN → label updates and dropdown closes.
- [ ] Escape key does not dismiss the modal.
- [ ] Clicking "Start a Spectrum" or "Join a Spectrum" hides the welcome modal and opens the corresponding form modal; canceling that form re-shows the welcome modal.
- [ ] On mobile viewport (≤ 375px) the modal still fits and buttons wrap to a column when needed.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)