### PR TITLE
fix(a11y): bump modal close buttons to btn-md for 44px touch target

### DIFF
--- a/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
+++ b/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
@@ -45,7 +45,7 @@
 	<div class="modal-box">
 		<form method="dialog">
 			<button
-				class="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
+				class="btn btn-md btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
 				onclick={() => (toggle = false)}>✕</button
 			>
 		</form>

--- a/frontend/src/lib/components/ConnectLiveModal.svelte
+++ b/frontend/src/lib/components/ConnectLiveModal.svelte
@@ -30,7 +30,7 @@
 	<div class="modal-box">
 		<form method="dialog">
 			<button
-				class="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
+				class="btn btn-md btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
 				onclick={() => (toggle = false)}>✕</button
 			>
 		</form>

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -45,7 +45,7 @@
 	<div class="modal-box">
 		<form method="dialog">
 			<button
-				class="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
+				class="btn btn-md btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
 				onclick={() => (toggle = false)}>✕</button
 			>
 		</form>

--- a/frontend/src/lib/components/JoinSpectrumModal.svelte
+++ b/frontend/src/lib/components/JoinSpectrumModal.svelte
@@ -44,7 +44,7 @@
 	<div class="modal-box">
 		<form method="dialog">
 			<button
-				class="btn btn-sm btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
+				class="btn btn-md btn-circle btn-ghost absolute top-2 right-2 hover:bg-rose-300"
 				onclick={() => (toggle = false)}>✕</button
 			>
 		</form>


### PR DESCRIPTION
## Summary

All four modal close (X) buttons used `btn-sm btn-circle` (~32px), below the 44px minimum touch target recommended by WCAG and iOS HIG.

## Fix

`btn-sm` → `btn-md` on close buttons in:

- `CreateSpectrumModal.svelte`
- `JoinSpectrumModal.svelte`
- `ConnectLiveModal.svelte`
- `AddLiveUserParticipantModal.svelte`

`btn-md` ensures 44px touch target while staying visually fine on desktop.

Closes #502