### PR TITLE
fix(ui): replace deprecated float utilities with flex in modal action rows

### DIFF
--- a/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
+++ b/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
@@ -114,8 +114,8 @@
 				{/each}
 			</ul>
 
-			<div>
-				<button class="btn btn-warning float-right" type="button" onclick={() => (toggle = false)}
+			<div class="flex justify-end">
+				<button class="btn btn-warning" type="button" onclick={() => (toggle = false)}
 					>{m.close()}</button
 				>
 			</div>

--- a/frontend/src/lib/components/ConnectLiveModal.svelte
+++ b/frontend/src/lib/components/ConnectLiveModal.svelte
@@ -72,9 +72,9 @@
 				bind:value={secret}
 				required
 			/>
-			<div>
-				<button class="btn btn-success float-left" type="submit">{m.start_connection()}</button>
-				<button class="btn btn-warning float-right" type="button" onclick={() => (toggle = false)}
+			<div class="flex justify-end gap-2">
+				<button class="btn btn-success" type="submit">{m.start_connection()}</button>
+				<button class="btn btn-warning" type="button" onclick={() => (toggle = false)}
 					>{m.cancel()}</button
 				>
 			</div>

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -123,9 +123,9 @@
 				>
 			</div>
 
-			<div>
-				<button class="btn btn-success float-left" type="submit">{m.start_spectrum()}</button>
-				<button class="btn btn-warning float-right" type="button" onclick={() => (toggle = false)}
+			<div class="flex justify-end gap-2">
+				<button class="btn btn-success" type="submit">{m.start_spectrum()}</button>
+				<button class="btn btn-warning" type="button" onclick={() => (toggle = false)}
 					>{m.cancel()}</button
 				>
 			</div>

--- a/frontend/src/lib/components/JoinSpectrumModal.svelte
+++ b/frontend/src/lib/components/JoinSpectrumModal.svelte
@@ -86,15 +86,15 @@
 			{:else}
 				<div class="mb-4"></div>
 			{/if}
-			<div>
-				<button class="btn btn-neutral float-left" type="submit" disabled={loading}>
+			<div class="flex justify-end gap-2">
+				<button class="btn btn-neutral" type="submit" disabled={loading}>
 					{#if loading}
 						<span class="loading loading-spinner loading-sm"></span>
 					{/if}
 					{m.join()}
 				</button>
 				<button
-					class="btn btn-warning float-right"
+					class="btn btn-warning"
 					onclick={() => (toggle = false)}
 					type="button"
 					disabled={loading}>{m.cancel()}</button


### PR DESCRIPTION
## Summary

Replace deprecated `float-left` / `float-right` utilities in modal action button rows with modern Flexbox layout.

## Changes

| Modal | Before | After |
|-------|--------|-------|
| `CreateSpectrumModal` | `<div>` + `float-left`/`float-right` | `<div class="flex justify-end gap-2">` |
| `ConnectLiveModal` | `<div>` + `float-left`/`float-right` | `<div class="flex justify-end gap-2">` |
| `JoinSpectrumModal` | `<div>` + `float-left`/`float-right` | `<div class="flex justify-end gap-2">` |
| `AddLiveUserParticipantModal` | `<div>` + `float-right` | `<div class="flex justify-end">` |

Closes #497