### PR TITLE
fix(responsive): constrain info dropdown width on mobile

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -116,7 +116,9 @@
 			<div tabindex="0" role="button" class="btn btn-ghost rounded-field">
 				<Fa icon={faCircleInfo} class="text-lg" />
 			</div>
-			<ul class="list dropdown-content bg-base-100 rounded-box z-1 max-w-[90vw] md:max-w-3xl shadow-sm">
+			<ul
+				class="list dropdown-content bg-base-100 rounded-box z-1 max-w-[90vw] shadow-sm md:max-w-3xl"
+			>
 				<li class="list-row">
 					<div>
 						<div class="font-bold">{m.info_what_is_spectrum()}</div>

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -116,7 +116,7 @@
 			<div tabindex="0" role="button" class="btn btn-ghost rounded-field">
 				<Fa icon={faCircleInfo} class="text-lg" />
 			</div>
-			<ul class="list dropdown-content bg-base-100 rounded-box z-1 w-3xl max-w-screen shadow-sm">
+			<ul class="list dropdown-content bg-base-100 rounded-box z-1 max-w-[90vw] md:max-w-3xl shadow-sm">
 				<li class="list-row">
 					<div>
 						<div class="font-bold">{m.info_what_is_spectrum()}</div>


### PR DESCRIPTION
## Summary

The Info dropdown in Header used `w-3xl max-w-screen` which overflows the viewport on mobile portrait.

## Fix

`w-3xl max-w-screen` → `max-w-[90vw] md:max-w-3xl`

- Mobile: constrained to 90% viewport width
- Desktop (md+): keeps 3xl max width

Closes #501