### PR TITLE
fix(ui): replace inline SVGs with FontAwesome Fa icons

### DIFF
--- a/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
+++ b/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages.js';
 	import type { LiveUser } from '$lib/social';
-	import { faPlus } from '@fortawesome/free-solid-svg-icons';
+	import { faPlus, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 	import Fa from 'svelte-fa';
 
 	interface ModalProps {
@@ -63,18 +63,7 @@
 			<p class="mb-4 text-sm">{m.search_participants()}</p>
 
 			<label class="input w-full">
-				<svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-					<g
-						stroke-linejoin="round"
-						stroke-linecap="round"
-						stroke-width="2.5"
-						fill="none"
-						stroke="currentColor"
-					>
-						<circle cx="11" cy="11" r="8"></circle>
-						<path d="m21 21-4.3-4.3"></path>
-					</g>
-				</svg>
+				<Fa icon={faMagnifyingGlass} class="h-[1em] opacity-50" />
 				<input type="search" bind:value={search} placeholder="Search" class="grow" />
 			</label>
 

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -7,7 +7,8 @@
 		faFileCircleQuestion,
 		faGlobe,
 		faPalette,
-		faSignal
+		faSignal,
+		faChevronDown
 	} from '@fortawesome/free-solid-svg-icons';
 	import Fa from 'svelte-fa';
 
@@ -182,15 +183,7 @@
 		<li class="dropdown dropdown-end tooltip" data-tip={m.languages()}>
 			<div tabindex="0" role="button" class="btn btn-ghost rounded-field">
 				<Fa icon={faGlobe} class="text-lg" />
-				<svg
-					width="12px"
-					height="12px"
-					class="inline-block h-2 w-2 fill-current opacity-60"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 2048 2048"
-				>
-					<path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path>
-				</svg>
+				<Fa icon={faChevronDown} class="inline-block h-2 w-2 opacity-60" />
 			</div>
 			<ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm">
 				<li>


### PR DESCRIPTION
## Summary

Two components used hand-rolled inline SVGs instead of the project-wide `Fa` (svelte-fa / FontAwesome) icons, breaking visual consistency.

## Changes

| File | Before | After |
|------|--------|-------|
| `AddLiveUserParticipantModal.svelte` | 12-line inline SVG (search icon) | `<Fa icon={faMagnifyingGlass} />` |
| `Header.svelte` | 9-line inline SVG (dropdown chevron) | `<Fa icon={faChevronDown} />` |

Both keep the same sizing/opacity classes as before.

Closes #504