### PR TITLE
fix(responsive): add overflow-x-auto wrapper on participants table

### DIFF
--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -1165,7 +1165,7 @@
 	<div class="flex flex-col md:min-h-0 md:overflow-hidden">
 		{#if !streamerMode}
 			<div
-				class="card bg-base-100 card-border border-base-300 from-base-content/5 order-2 mb-4 flex-none bg-linear-to-bl to-50% font-mono shadow-sm md:order-1"
+				class="card bg-base-100 card-border border-base-300 from-base-content/5 order-2 mb-4 flex-none overflow-x-auto bg-linear-to-bl to-50% font-mono shadow-sm md:order-1"
 			>
 				<table class="table">
 					<colgroup>


### PR DESCRIPTION
Closes #500

Adds `overflow-x-auto` to the participants table card wrapper so narrow viewports (<480px) get horizontal scroll instead of content overflow.

**Changes:** 1 file, +1/−1