### PR TITLE
fix(responsive): scale down chat placeholder font on <320px screens

### DIFF
--- a/frontend/src/lib/components/InputFlex.svelte
+++ b/frontend/src/lib/components/InputFlex.svelte
@@ -97,4 +97,10 @@
 		padding: 8px;
 		font-weight: normal;
 	}
+
+	@media (max-width: 319px) {
+		input::placeholder {
+			font-size: 0.625rem;
+		}
+	}
 </style>


### PR DESCRIPTION
Closes #513

Adds `@media (max-width: 319px)` rule in `InputFlex.svelte` that reduces placeholder `font-size` to `0.625rem` on very narrow viewports, preventing the long French placeholder ("Envoyer un message au chat") from being clipped.

**Files:** 1 file, +6