### PR TITLE
fix(responsive): wrap slice-count radios + cap mobile canvas height

### DIFF
--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -88,7 +88,7 @@
 			<!-- Nombre de cases -->
 			<div class="mb-4">
 				<span class="label text-base-content font-bold">{m.spectrum_slices()}</span>
-				<div class="flex gap-4">
+				<div class="flex flex-wrap gap-4">
 					<label class="label text-base-content cursor-pointer gap-2">
 						<input class="radio" type="radio" name="sliceCount" value={3} bind:group={sliceCount} />
 						3

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -962,7 +962,7 @@
 <div
 	class="relative mt-2 grid grid-cols-1 justify-items-start gap-2 md:mt-8 md:h-[50vh] md:grid-cols-[2fr_1fr] md:gap-4"
 >
-	<div class="flex h-max w-full md:h-full">
+	<div class="flex h-[50vh] w-full md:h-full">
 		<div class="card bg-base-100 h-max w-full shadow-sm md:h-full" bind:clientWidth={canvasWidth}>
 			<header class="w-full p-0 font-mono">
 				<label class="floating-label">


### PR DESCRIPTION
Closes #508, closes #509

**2 responsive fixes:**

1. **#508** — `CreateSpectrumModal`: `flex` → `flex flex-wrap` on slice-count radio group, preventing overflow on narrow modals
2. **#509** — `+page.svelte`: cap canvas at `h-[50vh]` on mobile instead of `h-max`, preventing canvas/chat collision below the fold

**Files:** 2 files, +2/−2