### PR TITLE
fix(responsive): add safe-area-inset support for Capacitor builds

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -49,6 +49,13 @@ html {
 	overflow-x: hidden;
 }
 
+body {
+	padding-top: env(safe-area-inset-top);
+	padding-bottom: env(safe-area-inset-bottom);
+	padding-left: env(safe-area-inset-left);
+	padding-right: env(safe-area-inset-right);
+}
+
 svg {
 	display: inline;
 }

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="robots" content="index, follow" />
 		%sveltekit.head%
 	</head>

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -937,7 +937,7 @@
 		</Header>
 	</div>
 {:else}
-	<div class="fixed top-5 right-[2rem] z-1000">
+	<div class="fixed top-[max(1.25rem,env(safe-area-inset-top))] right-[max(2rem,env(safe-area-inset-right))] z-1000">
 		<div class="tooltip tooltip-left" data-tip={m.leave_streamer()}>
 			<button
 				onclick={() => {

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -937,7 +937,9 @@
 		</Header>
 	</div>
 {:else}
-	<div class="fixed top-[max(1.25rem,env(safe-area-inset-top))] right-[max(2rem,env(safe-area-inset-right))] z-1000">
+	<div
+		class="fixed top-[max(1.25rem,env(safe-area-inset-top))] right-[max(2rem,env(safe-area-inset-right))] z-1000"
+	>
 		<div class="tooltip tooltip-left" data-tip={m.leave_streamer()}>
 			<button
 				onclick={() => {


### PR DESCRIPTION
Closes #506

**Changes:**
- `app.html`: add `viewport-fit=cover` meta tag to enable safe-area-inset CSS env vars
- `app.css`: add global `body` padding using `env(safe-area-inset-*)` for all four edges
- `+page.svelte`: streamer-mode button uses `max(rem, env(safe-area-inset-*))` for top/right positioning

**Files:** 3 files, +9/−2