### PR TITLE
fix(ui): replace raw Tailwind color utilities with DaisyUI semantic tokens

### DIFF
--- a/frontend/src/lib/components/ConnectLiveModal.svelte
+++ b/frontend/src/lib/components/ConnectLiveModal.svelte
@@ -39,7 +39,7 @@
 			onsubmit={() => channel && liveId && secret && onSubmit(channel, liveId, secret)}
 		>
 			<label
-				class="label text-base-content block font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
+				class="label text-base-content after:text-error block font-bold after:ml-0.5 after:content-['*']"
 				for="platform">{m.platform()}</label
 			>
 			<select class="select mb-6 block" id="platform" bind:value={channel}>
@@ -49,7 +49,7 @@
 				<option value="twitch">Twitch</option>
 			</select>
 			<label
-				class="label text-base-content font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
+				class="label text-base-content after:text-error font-bold after:ml-0.5 after:content-['*']"
 				for="claim">{m.live_id()}</label
 			>
 			<input
@@ -61,7 +61,7 @@
 				required
 			/>
 			<label
-				class="label text-base-content font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
+				class="label text-base-content after:text-error font-bold after:ml-0.5 after:content-['*']"
 				for="secret">{m.secret()}</label
 			>
 			<input

--- a/frontend/src/lib/components/CreateSpectrumModal.svelte
+++ b/frontend/src/lib/components/CreateSpectrumModal.svelte
@@ -52,7 +52,7 @@
 		<form class="p-4" onsubmit={handleSubmit}>
 			<!-- Pseudo -->
 			<label
-				class="label text-base-content font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
+				class="label text-base-content after:text-error font-bold after:ml-0.5 after:content-['*']"
 				for="nickname2">{m.your_nickname()}</label
 			>
 			<input

--- a/frontend/src/lib/components/JoinSpectrumModal.svelte
+++ b/frontend/src/lib/components/JoinSpectrumModal.svelte
@@ -50,7 +50,7 @@
 		</form>
 		<form class="p-4" onsubmit={handleSubmit}>
 			<label
-				class="label text-base-content font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
+				class="label text-base-content after:text-error font-bold after:ml-0.5 after:content-['*']"
 				for="spectrumId">{m.spectrum_id()}</label
 			>
 			<input
@@ -68,7 +68,7 @@
 				<div class="mb-4"></div>
 			{/if}
 			<label
-				class="label text-base-content font-bold after:ml-0.5 after:text-red-500 after:content-['*']"
+				class="label text-base-content after:text-error font-bold after:ml-0.5 after:content-['*']"
 				for="nickname1">{m.nickname()}</label
 			>
 			<input

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -1004,7 +1004,7 @@
 
 					{#if showDragHint}
 						<div class="drag-hint pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2">
-							<span class="rounded-full bg-black/60 px-4 py-2 text-sm text-white">
+							<span class="bg-neutral/60 text-neutral-content rounded-full px-4 py-2 text-sm">
 								{m.drag_hint()}
 							</span>
 						</div>
@@ -1229,7 +1229,7 @@
 												<Fa icon={faMicrophone} />
 											</div>
 											<div
-												class="swap-off btn btn-square rounded-xl border-0 bg-red-500/20 text-red-500"
+												class="swap-off btn btn-square bg-error/20 text-error rounded-xl border-0"
 											>
 												<Fa icon={faMicrophoneSlash} />
 											</div>
@@ -1265,7 +1265,7 @@
 										<div class="swap-on">
 											<Fa icon={faMicrophone} />
 										</div>
-										<div class="swap-off text-red-500">
+										<div class="swap-off text-error">
 											<Fa icon={faMicrophoneSlash} />
 										</div>
 									</label>
@@ -1278,7 +1278,7 @@
 									<div class="dropdown dropdown-click dropdown-bottom dropdown-center">
 										<button
 											tabindex="0"
-											class="btn btn-square rounded-xl border-0 bg-yellow-500/20 text-yellow-500"
+											class="btn btn-square bg-warning/20 text-warning rounded-xl border-0"
 										>
 											{#if other.volume && other.volume > 50}
 												<Fa icon={faVolumeHigh} />
@@ -1315,7 +1315,7 @@
 									{#if room.adminModeOn}
 										<div class="tooltip" data-tip={m.kick_participant()}>
 											<button
-												class="btn btn-square rounded-xl border-0 bg-orange-500/20 text-orange-500"
+												class="btn btn-square bg-warning/20 text-warning rounded-xl border-0"
 												onclick={() => {
 													promptKick(colorHex);
 												}}><Fa icon={faUserSlash} /></button
@@ -1323,7 +1323,7 @@
 										</div>
 										<div class="tooltip" data-tip={m.make_admin()}>
 											<button
-												class="btn btn-square rounded-xl border-0 bg-amber-500/20 text-amber-500"
+												class="btn btn-square bg-warning/20 text-warning rounded-xl border-0"
 												onclick={() => {
 													promptMakeAdmin(colorHex);
 												}}><Fa icon={faLock} /></button
@@ -1376,7 +1376,7 @@
 									><b>{room.nickname}{room.adminModeOn ? '*' : ''}</b></span
 								>
 							</div>
-							<div class="text-sm text-gray-500">
+							<div class="text-base-content/50 text-sm">
 								<label class="swap swap-flip">
 									<input
 										type="checkbox"
@@ -1390,7 +1390,7 @@
 									<div class="swap-on">
 										<Fa icon={faMicrophone} />
 									</div>
-									<div class="swap-off text-red-500">
+									<div class="swap-off text-error">
 										<Fa icon={faMicrophoneSlash} />
 									</div>
 								</label>
@@ -1423,12 +1423,12 @@
 								<div class="truncate text-base font-bold">
 									{other.nickname}
 								</div>
-								<div class="text-sm text-gray-500">
+								<div class="text-base-content/50 text-sm">
 									<label class="swap swap-flip cursor-default" class:swap-active={other.microphone}>
 										<div class="swap-on">
 											<Fa icon={faMicrophone} />
 										</div>
-										<div class="swap-off text-red-500">
+										<div class="swap-off text-error">
 											<Fa icon={faMicrophoneSlash} />
 										</div>
 									</label>
@@ -1467,10 +1467,10 @@
 								>
 								<span
 									class="text-sm"
-									class:text-black-800={log.type === 'message' || log.type === 'event'}
-									class:text-green-800={log.type === 'join'}
-									class:text-red-800={log.type === 'leave'}
-									class:text-orange-800={log.type === 'claim'}>{match?.[2]}</span
+									class:text-neutral={log.type === 'message' || log.type === 'event'}
+									class:text-success={log.type === 'join'}
+									class:text-error={log.type === 'leave'}
+									class:text-warning={log.type === 'claim'}>{match?.[2]}</span
 								>
 							</div>
 						</div>


### PR DESCRIPTION
Closes #503

Replaces all raw Tailwind color utilities with their DaisyUI semantic equivalents:

| Raw | Semantic |
|-----|----------|
| `bg-red-500/20`, `text-red-500`, `text-red-800` | `bg-error/20`, `text-error` |
| `bg-yellow-500/20`, `bg-orange-500/20`, `bg-amber-500/20` | `bg-warning/20` |
| `text-yellow/orange/amber-500`, `text-orange-800` | `text-warning` |
| `text-green-800` | `text-success` |
| `bg-black/60`, `text-white`, `text-gray-500` | `bg-neutral/60`, `text-neutral-content`, `text-base-content/50` |

**Files:** 4 files, +20/−20