### PR TITLE
fix(ui): enforce consistent border-radius scale across components

### DIFF
--- a/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
+++ b/frontend/src/lib/components/AddLiveUserParticipantModal.svelte
@@ -68,7 +68,7 @@
 			</label>
 
 			<!-- Filtered list of users-->
-			<ul class="my-4 max-h-60 min-h-30 space-y-2 overflow-y-auto rounded-sm">
+			<ul class="my-4 max-h-60 min-h-30 space-y-2 overflow-y-auto rounded-lg">
 				{#each filteredUsers() as user (user.userId)}
 					<li class="relative">
 						<button

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -71,7 +71,7 @@
 			<div
 				tabindex="0"
 				role="button"
-				class="btn btn-ghost rounded-field indicator after:ml-2 after:transition-transform after:duration-200 after:content-['+']"
+				class="btn btn-ghost indicator rounded-lg after:ml-2 after:transition-transform after:duration-200 after:content-['+']"
 				aria-label={m.server_status()}
 			>
 				<Fa icon={faSignal} class="text-lg " />
@@ -95,7 +95,7 @@
 			<div
 				tabindex="0"
 				role="button"
-				class="btn btn-ghost rounded-field"
+				class="btn btn-ghost rounded-lg"
 				aria-label={m.header_feedback()}
 			>
 				<Fa icon={faFileCircleQuestion} class="text-lg" />
@@ -103,7 +103,7 @@
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 			<div
 				tabindex="0"
-				class="card card-sm dropdown-content bg-base-100 rounded-box z-1 w-max shadow-sm"
+				class="card card-sm dropdown-content bg-base-100 z-1 w-max rounded-xl shadow-sm"
 			>
 				<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 				<div tabindex="0" class="card-body">
@@ -120,12 +120,7 @@
 			</div>
 		</li>
 		<li class="dropdown dropdown-end tooltip hidden md:block" data-tip={m.header_info()}>
-			<div
-				tabindex="0"
-				role="button"
-				class="btn btn-ghost rounded-field"
-				aria-label={m.header_info()}
-			>
+			<div tabindex="0" role="button" class="btn btn-ghost rounded-lg" aria-label={m.header_info()}>
 				<Fa icon={faCircleInfo} class="text-lg" />
 			</div>
 			<ul
@@ -153,7 +148,7 @@
 			</ul>
 		</li>
 		<li class="dropdown dropdown-end tooltip" data-tip={m.theme()}>
-			<div tabindex="0" role="button" class="btn btn-ghost rounded-field" aria-label={m.theme()}>
+			<div tabindex="0" role="button" class="btn btn-ghost rounded-lg" aria-label={m.theme()}>
 				<Fa icon={faPalette} class="text-lg" />
 			</div>
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -195,12 +190,7 @@
 			</ul>
 		</li>
 		<li class="dropdown dropdown-end tooltip" data-tip={m.languages()}>
-			<div
-				tabindex="0"
-				role="button"
-				class="btn btn-ghost rounded-field"
-				aria-label={m.languages()}
-			>
+			<div tabindex="0" role="button" class="btn btn-ghost rounded-lg" aria-label={m.languages()}>
 				<Fa icon={faGlobe} class="text-lg" />
 				<Fa icon={faChevronDown} class="inline-block h-2 w-2 opacity-60" />
 			</div>

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -1225,11 +1225,11 @@
 											class:swap-active={voice.voiceState.microphone &&
 												voice.voiceState.peerConnected}
 										>
-											<div class="swap-on btn btn-ghost btn-square rounded-xl">
+											<div class="swap-on btn btn-ghost btn-square rounded-lg">
 												<Fa icon={faMicrophone} />
 											</div>
 											<div
-												class="swap-off btn btn-square bg-error/20 text-error rounded-xl border-0"
+												class="swap-off btn btn-square bg-error/20 text-error rounded-lg border-0"
 											>
 												<Fa icon={faMicrophoneSlash} />
 											</div>
@@ -1278,7 +1278,7 @@
 									<div class="dropdown dropdown-click dropdown-bottom dropdown-center">
 										<button
 											tabindex="0"
-											class="btn btn-square bg-warning/20 text-warning rounded-xl border-0"
+											class="btn btn-square bg-warning/20 text-warning rounded-lg border-0"
 										>
 											{#if other.volume && other.volume > 50}
 												<Fa icon={faVolumeHigh} />
@@ -1315,7 +1315,7 @@
 									{#if room.adminModeOn}
 										<div class="tooltip" data-tip={m.kick_participant()}>
 											<button
-												class="btn btn-square bg-warning/20 text-warning rounded-xl border-0"
+												class="btn btn-square bg-warning/20 text-warning rounded-lg border-0"
 												onclick={() => {
 													promptKick(colorHex);
 												}}><Fa icon={faUserSlash} /></button
@@ -1323,7 +1323,7 @@
 										</div>
 										<div class="tooltip" data-tip={m.make_admin()}>
 											<button
-												class="btn btn-square bg-warning/20 text-warning rounded-xl border-0"
+												class="btn btn-square bg-warning/20 text-warning rounded-lg border-0"
 												onclick={() => {
 													promptMakeAdmin(colorHex);
 												}}><Fa icon={faLock} /></button


### PR DESCRIPTION
Closes #512

Applies the scale: **buttons** → `rounded-lg`, **cards** → `rounded-xl`, **avatars/pills** → `rounded-full`, **dropdowns** → `rounded-box` (DaisyUI standard).

**Alignments (12 violations fixed):**

| Count | Element | Before | After |
|-------|---------|--------|-------|
| ×5 | Header icon buttons | `rounded-field` | `rounded-lg` |
| ×5 | Participant action buttons | `rounded-xl` | `rounded-lg` |
| ×1 | Feedback card | `rounded-box` | `rounded-xl` |
| ×1 | Live user list | `rounded-sm` | `rounded-lg` |

**Files:** 3 files, +12/−22