### PR TITLE
feat: add F-Droid fastlane metadata (en-US, fr-FR)

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,16 @@
+Spectrum is a visual and interactive tool designed to facilitate constructive discussions between multiple people around beliefs or opinions.
+
+Inspired by Street Epistemology (SE), it allows each participant to position their level of confidence on a scale ranging from doubt to strong agreement, while explaining the reasons behind their stance.
+
+The goal is not to debate to convince, but to encourage critical thinking, idea clarification, and mutual understanding. By making divergences and convergences visible, Spectrum fosters respectful and introspective dialogue, whether in person or online.
+
+Features:
+- Anonymous participation — opinions without identity bias
+- Real-time visual positioning on a spectrum canvas
+- Live chat with emoji reactions
+- Voice chat (WebRTC) for live discussions
+- Spectrum slices: 3, 5, 7, or 9 positions
+- Multi-language: English, French
+- Streamer mode for public debates
+- Dark/light themes
+- No account required — join with a simple ID

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,3 @@
+Spectrum – Visual discussion tool
+
+Spectrum lets groups share opinions anonymously and see them visualized in real time. Start a new Spectrum to ask your group a question, or join an existing one with its ID.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Spectrum

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -1,0 +1,16 @@
+Spectrum est un outil visuel et interactif conçu pour faciliter les discussions constructives entre plusieurs personnes autour de croyances ou d'opinions.
+
+Inspiré de la méthode de l'entretien épistémique (EE), il permet à chacun de positionner son niveau de confiance sur une échelle allant du doute au fort assentiment, tout en expliquant les raisons qui motivent cette position.
+
+L'objectif n'est pas de débattre pour convaincre, mais d'encourager la réflexion critique, la clarification des idées et la compréhension mutuelle. En rendant visibles les divergences et les convergences, le Spectrum favorise un dialogue respectueux et introspectif, que ce soit en présentiel ou en ligne.
+
+Fonctionnalités :
+- Participation anonyme — les opinions sans biais d'identité
+- Positionnement visuel en temps réel sur un canevas spectrum
+- Chat en direct avec réactions emoji
+- Chat vocal (WebRTC) pour discussions en direct
+- Cases spectrum : 3, 5, 7 ou 9 positions
+- Multi-langue : anglais, français
+- Mode streamer pour débats publics
+- Thèmes clair/sombre
+- Aucun compte requis — rejoins avec un simple identifiant

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,0 +1,3 @@
+Spectrum – Outil de discussion visuelle
+
+Spectrum permet à un groupe de partager des opinions de façon anonyme et de les visualiser en temps réel. Démarre un nouveau Spectrum pour poser une question à ton groupe, ou rejoins-en un avec son identifiant.

--- a/fastlane/metadata/android/fr-FR/title.txt
+++ b/fastlane/metadata/android/fr-FR/title.txt
@@ -1,0 +1,1 @@
+Spectrum


### PR DESCRIPTION
Refs #330

**What this does:**
Adds F-Droid fastlane metadata structure with English and French descriptions.

**Structure:**
```
fastlane/metadata/android/
├── en-US/
│   ├── title.txt
│   ├── short_description.txt
│   ├── full_description.txt
│   └── images/phoneScreenshots/
└── fr-FR/
    ├── title.txt
    ├── short_description.txt
    ├── full_description.txt
    └── images/phoneScreenshots/
```

**F-Droid readiness check:**
- ✅ License: GPL-3.0 (F-Droid compatible)
- ✅ All deps open-source (MIT, Apache 2.0, CC BY 4.0)
- ✅ No proprietary SDKs or tracking
- ✅ Build reproducible via Capacitor + Gradle
- ⬜ Screenshots to add later

**Files:** 6 files, +40