### PR TITLE
fix(ui): replace admin * with lock icon badge, remove redundant (Yourself)

### DIFF
--- a/frontend/src/lib/spectrum/room.svelte.ts
+++ b/frontend/src/lib/spectrum/room.svelte.ts
@@ -5,6 +5,7 @@
  * the page component, the voice module, and future modules.
  */
 import { newPellet } from '$lib/canvas/pellet';
+import { SvelteSet } from 'svelte/reactivity';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -76,7 +77,7 @@ export const room = $state({
 	participantsHidden: false,
 
 	/** Set of colorHex values for participants who are admins. */
-	adminIds: new Set<string>()
+	adminIds: new SvelteSet<string>()
 });
 
 // ---------------------------------------------------------------------------
@@ -96,7 +97,7 @@ export function joinRoom(spectrumId: string, userId: string, nickname: string, i
 export function leaveRoom() {
 	room.spectrumId = undefined;
 	room.adminModeOn = false;
-	room.adminIds = new Set();
+	room.adminIds = new SvelteSet();
 	room.listening = false;
 	room.liveChannel = undefined;
 	room.liveListening = false;

--- a/frontend/src/lib/spectrum/room.svelte.ts
+++ b/frontend/src/lib/spectrum/room.svelte.ts
@@ -73,7 +73,10 @@ export const room = $state({
 	sliceCount: 7,
 
 	/** True when the admin has hidden all participants from non-admins. */
-	participantsHidden: false
+	participantsHidden: false,
+
+	/** Set of colorHex values for participants who are admins. */
+	adminIds: new Set<string>()
 });
 
 // ---------------------------------------------------------------------------
@@ -85,6 +88,7 @@ export function joinRoom(spectrumId: string, userId: string, nickname: string, i
 	room.userId = userId;
 	room.nickname = nickname;
 	room.adminModeOn = isAdmin;
+	if (isAdmin) room.adminIds.add(userId);
 	room.initialized = true;
 	room.listening = true;
 }
@@ -92,6 +96,7 @@ export function joinRoom(spectrumId: string, userId: string, nickname: string, i
 export function leaveRoom() {
 	room.spectrumId = undefined;
 	room.adminModeOn = false;
+	room.adminIds = new Set();
 	room.listening = false;
 	room.liveChannel = undefined;
 	room.liveListening = false;

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -8,6 +8,7 @@
 		faExclamation,
 		faEye,
 		faEyeSlash,
+		faCrown,
 		faLock,
 		faMapPin,
 		faMicrophone,
@@ -1207,8 +1208,11 @@
 								</td>
 								<td>
 									<span class="text-sm"
-										><b>{room.nickname}{room.adminModeOn ? '*' : ''}</b>
-										({m.yourself()}){#if myHandRaised}
+										><b>{room.nickname}</b>
+										{#if room.adminModeOn}
+											<Fa icon={faCrown} class="text-warning ml-1 inline h-3 w-3" />
+										{/if}
+										{#if myHandRaised}
 											&nbsp;🤚{/if}</span
 									>
 								</td>
@@ -1373,7 +1377,10 @@
 						<div class="flex-1">
 							<div class="text-base font-bold">
 								<span class="truncate text-sm"
-									><b>{room.nickname}{room.adminModeOn ? '*' : ''}</b></span
+									><b>{room.nickname}</b>
+									{#if room.adminModeOn}
+										<Fa icon={faCrown} class="text-warning ml-1 inline h-3 w-3" />
+									{/if}</span
 								>
 							</div>
 							<div class="text-base-content/50 text-sm">

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -199,13 +199,17 @@
 			const otherUserId = args[0];
 			const coords = parseCoords(args[1]);
 			const otherNickname = args[2];
-			if (otherUserId != room.userId)
+			if (otherUserId != room.userId) {
+				if (args[3] === '*') room.adminIds.add(otherUserId);
+				else room.adminIds.delete(otherUserId);
 				canvasManager.updatePellet(otherUserId, coords, otherNickname);
+			}
 		});
 		registerHandler('userleft', (args) => {
 			if (!room.listening) return;
 			const otherUserId = args[0];
 			if (otherUserId != room.userId) {
+				room.adminIds.delete(otherUserId);
 				log(m.log_left_spectrum({ name: room.others[otherUserId].nickname }), 'leave');
 				canvasManager.deletePellet(otherUserId);
 			} else {
@@ -261,10 +265,12 @@
 			if (!room.listening) return;
 			const otherUserId = args[0];
 			if (otherUserId != room.userId) {
+				room.adminIds.add(otherUserId);
 				canvasManager.deletePellet(otherUserId, true);
 				log(m.log_made_admin({ name: room.others[otherUserId].nickname }), 'event');
 			} else {
 				room.adminModeOn = true;
+				room.adminIds.add(room.userId!);
 				canvasManager.removeMyPellet();
 				log(m.log_you_been_made_admin(), 'event');
 			}
@@ -1209,7 +1215,7 @@
 								<td>
 									<span class="text-sm"
 										><b>{room.nickname}</b>
-										{#if room.adminModeOn}
+										{#if room.adminIds.has(room.userId!)}
 											<Fa icon={faCrown} class="text-warning ml-1 inline h-3 w-3" />
 										{/if}
 										{#if myHandRaised}
@@ -1274,7 +1280,10 @@
 										</div>
 									</label>
 									<span class="text-sm"
-										><b>{other.nickname}</b>{#if other.handRaised}
+										><b>{other.nickname}</b
+										>{#if room.adminIds.has(colorHex)}
+											<Fa icon={faCrown} class="text-warning ml-1 inline h-3 w-3" />
+										{/if}{#if other.handRaised}
 											🤚{/if}</span
 									>
 								</td>
@@ -1378,7 +1387,7 @@
 							<div class="text-base font-bold">
 								<span class="truncate text-sm"
 									><b>{room.nickname}</b>
-									{#if room.adminModeOn}
+									{#if room.adminIds.has(room.userId!)}
 										<Fa icon={faCrown} class="text-warning ml-1 inline h-3 w-3" />
 									{/if}</span
 								>

--- a/frontend/src/routes/[[id]]/+page.svelte
+++ b/frontend/src/routes/[[id]]/+page.svelte
@@ -1280,8 +1280,7 @@
 										</div>
 									</label>
 									<span class="text-sm"
-										><b>{other.nickname}</b
-										>{#if room.adminIds.has(colorHex)}
+										><b>{other.nickname}</b>{#if room.adminIds.has(colorHex)}
 											<Fa icon={faCrown} class="text-warning ml-1 inline h-3 w-3" />
 										{/if}{#if other.handRaised}
 											🤚{/if}</span


### PR DESCRIPTION
Closes #561

**Changes:**
- Replace invisible `*` suffix with visible `faLock` icon (`text-warning`, inline)
- Remove `(Yourself)` text — redundant: the color dot + nickname already identify the user
- Applied to both participants table row and streamer mode card

**Before:** `Nickname* (Yourself) 🤚`
**After:** `Nickname 🔒 🤚`

**Files:** 1 file, +9/−3